### PR TITLE
Efficiency

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -572,7 +572,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	public ResultSequence visit(OrExpr orex) {
 		boolean res[] = do_logic_exp(orex);
 
-		return new XSBoolean(res[0] || res[1]);
+		return XSBoolean.valueOf(res[0] || res[1]);
 	}
 
 	/**
@@ -585,7 +585,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	public ResultSequence visit(AndExpr andex) {
 		boolean res[] = do_logic_exp(andex);
 
-		return new XSBoolean(res[0] && res[1]);
+		return XSBoolean.valueOf(res[0] && res[1]);
 	}
 
 	private ResultSequence node_cmp(int type, Collection<ResultSequence> args) {
@@ -928,7 +928,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 
 		// get the sequence type
 		SequenceType seqt = (SequenceType) ioexp.right();
-		return new XSBoolean(isInstanceOf(rs, seqt));
+		return XSBoolean.valueOf(isInstanceOf(rs, seqt));
 	}
 		
 	private boolean isInstanceOf(ResultSequence rs, SequenceType seqt) {
@@ -992,7 +992,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 			castable = false;
 		}
 
-		return new XSBoolean(castable);
+		return XSBoolean.valueOf(castable);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -712,7 +712,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	public ResultSequence visit(RangeExpr rex) {
 		ResultSequence one = rex.left().accept(this);
 		ResultSequence two = rex.right().accept(this);
-		if (one.empty() || two.empty()) return ResultSequenceFactory.create_new(); 
+		if (one.empty() || two.empty()) return ResultBuffer.EMPTY; 
 		Collection<ResultSequence> args = new ArrayList<ResultSequence>();
 		args.add(one);
 		args.add(two);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -572,8 +572,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	public ResultSequence visit(OrExpr orex) {
 		boolean res[] = do_logic_exp(orex);
 
-		return ResultSequenceFactory
-				.create_new(new XSBoolean(res[0] || res[1]));
+		return new XSBoolean(res[0] || res[1]);
 	}
 
 	/**
@@ -586,8 +585,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	public ResultSequence visit(AndExpr andex) {
 		boolean res[] = do_logic_exp(andex);
 
-		return ResultSequenceFactory
-				.create_new(new XSBoolean(res[0] && res[1]));
+		return new XSBoolean(res[0] && res[1]);
 	}
 
 	private ResultSequence node_cmp(int type, Collection<ResultSequence> args) {
@@ -930,7 +928,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 
 		// get the sequence type
 		SequenceType seqt = (SequenceType) ioexp.right();
-		return ResultSequenceFactory.create_new(new XSBoolean(isInstanceOf(rs, seqt)));
+		return new XSBoolean(isInstanceOf(rs, seqt));
 	}
 		
 	private boolean isInstanceOf(ResultSequence rs, SequenceType seqt) {
@@ -994,7 +992,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 			castable = false;
 		}
 
-		return ResultSequenceFactory.create_new(new XSBoolean(castable));
+		return new XSBoolean(castable);
 	}
 
 	/**
@@ -1031,7 +1029,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 
 		// prepare args from function
 		Collection<ResultSequence> args = new ArrayList<ResultSequence>();
-		args.add(ResultSequenceFactory.create_new(aat));
+		args.add(aat);
 
 		try {
 			Function function = cexp.function();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/function/XSCtrLibrary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/function/XSCtrLibrary.java
@@ -59,7 +59,7 @@ public class XSCtrLibrary extends ConstructorFL {
 		add_type(new XSName());
 		add_type(new XSNCName());
 		add_type(new XSNMTOKEN());
-		add_type(new XSBoolean());
+		add_type(XSBoolean.FALSE);
 		add_type(new XSUntypedAtomic());
 		add_type(new XSNotation());
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
@@ -29,7 +29,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -93,12 +92,12 @@ public class FnAvg extends Function {
 			if( conv != null ){
 				
 				if (conv instanceof XSDouble && ((XSDouble)conv).nan() || conv instanceof XSFloat && ((XSFloat)conv).nan()) {
-					return ResultSequenceFactory.create_new(tp.promote(new XSFloat(Float.NaN)));
+					return tp.promote(new XSFloat(Float.NaN));
 				}
 				if (total == null) {
 					total = (MathPlus)conv; 
 				} else {
-					total = (MathPlus)total.plus(ResultSequenceFactory.create_new(conv)).first();
+					total = (MathPlus)total.plus(conv).first();
 				}
 			}
 		}
@@ -106,7 +105,7 @@ public class FnAvg extends Function {
 		if (!(total instanceof MathDiv))
 			DynamicError.throw_type_error();
 
-		return ((MathDiv)total).div(ResultSequenceFactory.create_new(new XSInteger(BigInteger.valueOf(elems))));
+		return ((MathDiv)total).div(new XSInteger(BigInteger.valueOf(elems)));
 	}
 	
 	@Override

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -77,7 +78,7 @@ public class FnAvg extends Function {
 		ResultSequence arg = args.iterator().next();
 
 		if (arg.empty())
-			return ResultSequenceFactory.create_new();
+			return ResultBuffer.EMPTY;
 
 		int elems = 0;
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnBoolean.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnBoolean.java
@@ -21,7 +21,6 @@ import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.CalendarType;
@@ -64,7 +63,7 @@ public class FnBoolean extends Function {
 
 		ResultSequence argument = args.iterator().next();
 
-		return ResultSequenceFactory.create_new(fn_boolean(argument));
+		return fn_boolean(argument);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCodepointEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCodepointEqual.java
@@ -99,7 +99,7 @@ public class FnCodepointEqual extends Function {
 
 		// This delegates to FnCompare
 		BigInteger result = FnCompare.compare_string(CollationProvider.CODEPOINT_COLLATION, xstr1, xstr2, dynamicContext);
-		if (result != null) rs.add(new XSBoolean(BigInteger.ZERO.equals(result)));
+		if (result != null) rs.add(XSBoolean.valueOf(BigInteger.ZERO.equals(result)));
 		
 		return rs.getSequence();
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
@@ -114,7 +115,7 @@ public class FnCompare extends Function {
 		if (result != null) {
 			return ResultSequenceFactory.create_new(new XSInteger(result));
 		} else {
-			return ResultSequenceFactory.create_new();			
+			return ResultBuffer.EMPTY;
 		}
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
@@ -25,7 +25,6 @@ import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSInteger;
@@ -113,7 +112,7 @@ public class FnCompare extends Function {
 
 		BigInteger result = compare_string(collationUri, xstr1, xstr2, context);
 		if (result != null) {
-			return ResultSequenceFactory.create_new(new XSInteger(result));
+			return new XSInteger(result);
 		} else {
 			return ResultBuffer.EMPTY;
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCount.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCount.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSInteger;
 
@@ -65,6 +64,6 @@ public class FnCount extends Function {
 		Iterator<ResultSequence> citer = args.iterator();
 		ResultSequence arg = citer.next();
 
-		return ResultSequenceFactory.create_new(new XSInteger(BigInteger.valueOf(arg.size())));
+		return new XSInteger(BigInteger.valueOf(arg.size()));
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentDate.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentDate.java
@@ -19,7 +19,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSDate;
@@ -71,6 +70,6 @@ public class FnCurrentDate extends Function {
 		XSDayTimeDuration tz = new XSDayTimeDuration(dc.getTimezoneOffset());
 		AnyType res = new XSDate(dc.getCurrentDateTime(), tz);
 
-		return ResultSequenceFactory.create_new(res);
+		return res;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentDateTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentDateTime.java
@@ -21,7 +21,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSDateTime;
@@ -76,6 +75,6 @@ public class FnCurrentDateTime extends Function {
 
 		AnyType res = new XSDateTime(dc.getCurrentDateTime(), tz);
 
-		return ResultSequenceFactory.create_new(res);
+		return res;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCurrentTime.java
@@ -21,7 +21,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSDayTimeDuration;
@@ -75,6 +74,6 @@ public class FnCurrentTime extends Function {
 
 		AnyType res = new XSTime(dc.getCurrentDateTime(), tz);
 
-		return ResultSequenceFactory.create_new(res);
+		return res;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
@@ -22,7 +22,6 @@ import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.NodeType;
@@ -92,7 +91,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 
 		boolean result = deep_equal(arg1, arg2, context, collationURI);
 
-		return ResultSequenceFactory.create_new(new XSBoolean(result));
+		return new XSBoolean(result);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
@@ -91,7 +91,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 
 		boolean result = deep_equal(arg1, arg2, context, collationURI);
 
-		return new XSBoolean(result);
+		return XSBoolean.valueOf(result);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDoc.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDoc.java
@@ -20,9 +20,9 @@ import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.DocType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -84,7 +84,7 @@ public class FnDoc extends Function {
 		ResultSequence arg1 = argiter.next();
 
 		if (arg1.empty())
-			return ResultSequenceFactory.create_new();
+			return ResultBuffer.EMPTY;
 
 		String uri = ((XSString) arg1.item(0)).value();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnFalse.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnFalse.java
@@ -16,7 +16,6 @@ import java.util.Collection;
 
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSBoolean;
 
@@ -56,6 +55,6 @@ public class FnFalse extends Function {
 	public static ResultSequence fn_false(Collection<ResultSequence> args) throws DynamicError {
 		assert args.size() == 0;
 
-		return ResultSequenceFactory.create_new(new XSBoolean(false));
+		return new XSBoolean(false);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnFalse.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnFalse.java
@@ -55,6 +55,6 @@ public class FnFalse extends Function {
 	public static ResultSequence fn_false(Collection<ResultSequence> args) throws DynamicError {
 		assert args.size() == 0;
 
-		return new XSBoolean(false);
+		return XSBoolean.FALSE;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnImplicitTimezone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnImplicitTimezone.java
@@ -20,7 +20,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSDayTimeDuration;
@@ -68,6 +67,6 @@ public class FnImplicitTimezone extends Function {
 
 		AnyType res = new XSDayTimeDuration(dc.getTimezoneOffset());
 
-		return ResultSequenceFactory.create_new(res);
+		return res;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLang.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLang.java
@@ -104,7 +104,7 @@ public class FnLang extends Function {
 		
 		NodeType an = (NodeType) arg2.first();
 
-		return new XSBoolean(test_lang(an.node_value(), lang));
+		return XSBoolean.valueOf(test_lang(an.node_value(), lang));
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLast.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLast.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSInteger;
 
@@ -71,6 +70,6 @@ public class FnLast extends Function {
 
 		assert last != 0;
 
-		return ResultSequenceFactory.create_new(new XSInteger(BigInteger.valueOf(last)));
+		return new XSInteger(BigInteger.valueOf(last));
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
@@ -75,7 +76,7 @@ public class FnMax extends Function {
 
 		ResultSequence arg = get_arg(args, CmpGt.class);
 		if (arg.empty())
-			return ResultSequenceFactory.create_new();
+			return ResultBuffer.EMPTY;
 
 		CmpGt max = null;
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
@@ -25,7 +25,6 @@ import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -89,14 +88,14 @@ public class FnMax extends Function {
 			if( conv != null ){
 				
 				if (conv instanceof XSDouble && ((XSDouble)conv).nan() || conv instanceof XSFloat && ((XSFloat)conv).nan()) {
-					return ResultSequenceFactory.create_new(tp.promote(new XSFloat(Float.NaN)));
+					return tp.promote(new XSFloat(Float.NaN));
 				}
 				if (max == null || ((CmpGt)conv).gt((AnyType)max, dynamicContext)) {
 					max = (CmpGt)conv;
 				}
 			}
 		}
-		return ResultSequenceFactory.create_new((AnyType) max);
+		return (AnyType) max;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
@@ -25,7 +25,6 @@ import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -89,14 +88,14 @@ public class FnMin extends Function {
 			if( conv != null ){
 				
 				if (conv instanceof XSDouble && ((XSDouble)conv).nan() || conv instanceof XSFloat && ((XSFloat)conv).nan()) {
-					return ResultSequenceFactory.create_new(tp.promote(new XSFloat(Float.NaN)));
+					return tp.promote(new XSFloat(Float.NaN));
 				}
 				if (max == null || ((CmpLt)conv).lt((AnyType)max, context)) {
 					max = (CmpLt)conv;
 				}
 			}
 		}
-		return ResultSequenceFactory.create_new((AnyType) max);
+		return (AnyType) max;
 	}
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
@@ -75,7 +76,7 @@ public class FnMin extends Function {
 
 		ResultSequence arg = FnMax.get_arg(args, CmpLt.class);
 		if (arg.empty())
-			return ResultSequenceFactory.create_new();
+			return ResultBuffer.EMPTY;
 
 		CmpLt max = null;
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNot.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNot.java
@@ -67,7 +67,7 @@ public class FnNot extends Function {
 		if (ret.value() == false)
 			answer = true;
 
-		return new XSBoolean(answer);
+		return XSBoolean.valueOf(answer);
 	}
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNot.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNot.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSBoolean;
 
@@ -68,7 +67,7 @@ public class FnNot extends Function {
 		if (ret.value() == false)
 			answer = true;
 
-		return ResultSequenceFactory.create_new(new XSBoolean(answer));
+		return new XSBoolean(answer);
 	}
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnPosition.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnPosition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSInteger;
 
@@ -68,7 +67,6 @@ public class FnPosition extends Function {
 			throw DynamicError.contextUndefined();
 		}
 		
-		return ResultSequenceFactory.create_new(new XSInteger(BigInteger.valueOf(ec
-				.getContextPosition())));
+		return new XSInteger(BigInteger.valueOf(ec.getContextPosition()));
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStaticBaseUri.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStaticBaseUri.java
@@ -18,7 +18,6 @@ import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.StaticContext;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSAnyURI;
 
@@ -66,6 +65,6 @@ public class FnStaticBaseUri extends Function {
 		assert sc != null;
 
 		// make a copy prolly
-		return ResultSequenceFactory.create_new(new XSAnyURI(sc.getBaseUri().toString()));
+		return new XSAnyURI(sc.getBaseUri().toString());
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.TypeError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
@@ -88,7 +87,7 @@ public class FnSum extends Function {
 
 
 		if (arg.empty())
-			return ResultSequenceFactory.create_new(zero);
+			return zero;
 
 		MathPlus total = null;
 
@@ -103,15 +102,15 @@ public class FnSum extends Function {
 			}
 			
 			if (conv instanceof XSDouble && ((XSDouble)conv).nan() || conv instanceof XSFloat && ((XSFloat)conv).nan()) {
-				return ResultSequenceFactory.create_new(tp.promote(new XSFloat(Float.NaN)));
+				return tp.promote(new XSFloat(Float.NaN));
 			}
 			if (total == null) {
 				total = (MathPlus)conv; 
 			} else {
-				total = (MathPlus)total.plus(ResultSequenceFactory.create_new(conv)).first();
+				total = (MathPlus)total.plus(conv).first();
 			}
 		}
 		
-		return ResultSequenceFactory.create_new((AnyType) total);
+		return (AnyType) total;
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
@@ -28,7 +28,6 @@ import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.TypeError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.NumericType;
@@ -218,8 +217,8 @@ public class FsEq extends Function {
 		// rule d
 		// if value comparison is true, return true.
 
-		ResultSequence one = ResultSequenceFactory.create_new(a);
-		ResultSequence two = ResultSequenceFactory.create_new(b);
+		ResultSequence one = a;
+		ResultSequence two = b;
 
 		Collection<ResultSequence> args = new ArrayList<ResultSequence>();
 		args.add(one);
@@ -285,7 +284,7 @@ public class FsEq extends Function {
 
 		// XXX ?
 		if (one.empty() || two.empty())
-			return ResultSequenceFactory.create_new(new XSBoolean(false));
+			return new XSBoolean(false);
 
 		// atomize
 		one = FnData.atomize(one);
@@ -298,12 +297,11 @@ public class FsEq extends Function {
 				AnyType b = (AnyType) j.next();
 
 				if (do_general_pair(a, b, op, dc))
-					return ResultSequenceFactory
-							.create_new(new XSBoolean(true));
+					return new XSBoolean(true);
 			}
 		}
 
-		return ResultSequenceFactory.create_new(new XSBoolean(false));
+		return new XSBoolean(false);
 	}
 
 	public interface CmpValueOp<T> {
@@ -352,6 +350,6 @@ public class FsEq extends Function {
 			DynamicError.throw_type_error();
 
 		boolean cmpres = op.execute(op.getType().cast(arg), (AnyType)arg2.first(), context);
-		return ResultSequenceFactory.create_new(new XSBoolean(cmpres));
+		return new XSBoolean(cmpres);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
@@ -284,7 +284,7 @@ public class FsEq extends Function {
 
 		// XXX ?
 		if (one.empty() || two.empty())
-			return new XSBoolean(false);
+			return XSBoolean.FALSE;
 
 		// atomize
 		one = FnData.atomize(one);
@@ -297,11 +297,11 @@ public class FsEq extends Function {
 				AnyType b = (AnyType) j.next();
 
 				if (do_general_pair(a, b, op, dc))
-					return new XSBoolean(true);
+					return XSBoolean.TRUE;
 			}
 		}
 
-		return new XSBoolean(false);
+		return XSBoolean.FALSE;
 	}
 
 	public interface CmpValueOp<T> {
@@ -350,6 +350,6 @@ public class FsEq extends Function {
 			DynamicError.throw_type_error();
 
 		boolean cmpres = op.execute(op.getType().cast(arg), (AnyType)arg2.first(), context);
-		return new XSBoolean(cmpres);
+		return XSBoolean.valueOf(cmpres);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
@@ -71,7 +71,7 @@ public class FsGe extends Function {
 		if (((XSBoolean) equal.first()).value())
 			return equal;
 
-		return new XSBoolean(false);
+		return XSBoolean.FALSE;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
@@ -20,7 +20,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSBoolean;
 
@@ -72,7 +71,7 @@ public class FsGe extends Function {
 		if (((XSBoolean) equal.first()).value())
 			return equal;
 
-		return ResultSequenceFactory.create_new(new XSBoolean(false));
+		return new XSBoolean(false);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
@@ -72,7 +72,7 @@ public class FsLe extends Function {
 		if (((XSBoolean) equal.first()).value())
 			return equal;
 
-		return new XSBoolean(false);
+		return XSBoolean.FALSE;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
@@ -20,7 +20,6 @@ import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSBoolean;
 
@@ -73,7 +72,7 @@ public class FsLe extends Function {
 		if (((XSBoolean) equal.first()).value())
 			return equal;
 
-		return ResultSequenceFactory.create_new(new XSBoolean(false));
+		return new XSBoolean(false);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
@@ -220,13 +220,13 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 					// create a new item of the expected
 					// type initialized with from the string
 					// value of the item
-					ResultSequence converted = null;
+					AnyType converted;
 					if (expected_aat instanceof XSString) {
 					   XSString strType = new XSString(item.getStringValue());
-					   converted = ResultSequenceFactory.create_new(strType);
+					   converted = strType;
 					}
 					else {
-					   converted = ResultSequenceFactory.create_new(item);
+					   converted = item;
 					}
 					
 					result.concat(converted);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
@@ -106,7 +106,7 @@ public abstract class NodeType extends AnyType {
 
 	// XXX element should override
 	public ResultSequence nilled() {
-		return ResultSequenceFactory.create_new();
+		return ResultBuffer.EMPTY;
 	}
 
 	// a little factory for converting from DOM to our representation

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/SchemaTypeValueFactory.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/SchemaTypeValueFactory.java
@@ -35,8 +35,7 @@ public class SchemaTypeValueFactory {
 		}
 		
 		if (typeDef == XSConstants.BOOLEAN_DT) {
-			String newStrValue = ("1".equals(strValue) || "true".equals(strValue)) ? "true" : "false";
-			return new XSBoolean(Boolean.valueOf(newStrValue).booleanValue());
+			return XSBoolean.valueOf("1".equals(strValue) || "true".equals(strValue));
 		}
 		
 		if (typeDef == XSConstants.DATE_DT) {       

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
@@ -30,23 +30,32 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLi
  */
 public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 	private static final String XS_BOOLEAN = "xs:boolean";
+	@SuppressWarnings("deprecation")
 	public static final XSBoolean TRUE = new XSBoolean(true);
+	@SuppressWarnings("deprecation")
 	public static final XSBoolean FALSE = new XSBoolean(false);
-	private boolean _value;
+	private final boolean _value;
 
 	/**
 	 * Initiates the new representation to the boolean supplied
 	 * 
 	 * @param x
 	 *       Initializes this datatype to represent this boolean
+	 *
+	 * @deprecated Use {@link #TRUE}, {@link #FALSE}, or {@link #valueOf}
+	 * instead.
 	 */
+	@Deprecated
 	public XSBoolean(boolean x) {
 		_value = x;
 	}
 
 	/**
 	 * Initiates to a default representation of false.
+	 *
+	 * @deprecated Use {@link #FALSE} instead.
 	 */
+	@Deprecated
 	public XSBoolean() {
 	  this(false);
 	}
@@ -205,8 +214,7 @@ public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 		return BuiltinTypeLibrary.XS_BOOLEAN;
 	}
 
-	public static org.eclipse.wst.xml.xpath2.api.ResultSequence valueOf(
-			boolean answer) {
+	public static XSBoolean valueOf(boolean answer) {
 		return answer ? TRUE : FALSE;
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
@@ -31,7 +31,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
@@ -442,7 +441,7 @@ Cloneable {
 					.newDuration(val.getStringValue());
 			xmlCal.add(dtduration.negate());
 			res = new XSDate(xmlCal.toGregorianCalendar(), res.tz());
-			return ResultSequenceFactory.create_new(res);
+			return res;
 		} catch (CloneNotSupportedException ex) {
 		}
 		return null;
@@ -454,7 +453,7 @@ Cloneable {
 			XSDate res = (XSDate) clone();
 
 			res.calendar().add(Calendar.MONTH, val.monthValue() * -1);
-			return ResultSequenceFactory.create_new(res);
+			return res;
 		} catch (CloneNotSupportedException ex) {
 
 		}
@@ -469,8 +468,7 @@ Cloneable {
 		long duration = thisCal.getTimeInMillis()
 				- thatCal.getTimeInMillis();
 		dtduration = _datatypeFactory.newDuration(duration);
-		return ResultSequenceFactory.create_new(XSDayTimeDuration
-				.parseDTDuration(dtduration.toString()));
+		return XSDayTimeDuration.parseDTDuration(dtduration.toString());
 	}
 
 	/**
@@ -499,7 +497,7 @@ Cloneable {
 				XSDate res = (XSDate) clone();
 
 				res.calendar().add(Calendar.MONTH, val.monthValue());
-				return ResultSequenceFactory.create_new(res);
+				return res;
 			} else if (at instanceof XSDayTimeDuration) {
 				XSDayTimeDuration val = (XSDayTimeDuration) at;
 
@@ -514,7 +512,7 @@ Cloneable {
 
 				res.calendar().add(Calendar.MILLISECOND,
 						(int) (val.time_value() * 1000.0));
-				return ResultSequenceFactory.create_new(res);
+				return res;
 			} else {
 				DynamicError.throw_type_error();
 				return null; // unreach

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
@@ -30,7 +30,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
@@ -870,8 +869,7 @@ Cloneable {
 		long duration = thisCal.getTimeInMillis()
 				- thatCal.getTimeInMillis();
 		Duration dtduration = _datatypeFactory.newDuration(duration);
-		return ResultSequenceFactory.create_new(XSDayTimeDuration
-				.parseDTDuration(dtduration.toString()));
+		return XSDayTimeDuration.parseDTDuration(dtduration.toString());
 	}
 
 	private ResultSequence minusXSDayTimeDuration(Item at) {
@@ -885,7 +883,7 @@ Cloneable {
 			xmlCal.add(dtduration.negate());
 			res = new XSDateTime(xmlCal.toGregorianCalendar(), res.tz());
 
-			return ResultSequenceFactory.create_new(res);
+			return res;
 		} catch (CloneNotSupportedException ex) {
 
 		}
@@ -899,7 +897,7 @@ Cloneable {
 			XSDateTime res = (XSDateTime) clone();
 
 			res.calendar().add(Calendar.MONTH, val.monthValue() * -1);
-			return ResultSequenceFactory.create_new(res);
+			return res;
 		} catch (CloneNotSupportedException ex) {
 
 		}
@@ -933,7 +931,7 @@ Cloneable {
 				XSDateTime res = (XSDateTime) clone();
 
 				res.calendar().add(Calendar.MONTH, val.monthValue());
-				return ResultSequenceFactory.create_new(res);
+				return res;
 			} else if (at instanceof XSDayTimeDuration) {
 				XSDuration val = (XSDuration) at;
 
@@ -946,7 +944,7 @@ Cloneable {
 						.newDuration(val.getStringValue());
 				xmlCal.add(dtduration);
 				res = new XSDateTime(xmlCal.toGregorianCalendar(), res.tz());
-				return ResultSequenceFactory.create_new(res);
+				return res;
 			} else {
 				DynamicError.throw_type_error();
 				return null; // unreach

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
@@ -25,7 +25,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
@@ -265,7 +264,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 		
 		double res = value() + val.value();
 
-		return ResultSequenceFactory.create_new(new XSDayTimeDuration(res));
+		return new XSDayTimeDuration(res);
 	}
 
 	/**
@@ -284,7 +283,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 
 		double res = value() - val.value();
 
-		return ResultSequenceFactory.create_new(new XSDayTimeDuration(res));
+		return new XSDayTimeDuration(res);
 	}
 
 	/**
@@ -303,7 +302,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 		if (arg.size() == 1) {
 			Item argValue = arg.first();
             if (argValue instanceof XSDecimal) {
-            	convertedRS = ResultSequenceFactory.create_new(new XSDouble(argValue.getStringValue()));	
+            	convertedRS = new XSDouble(argValue.getStringValue());	
             }
 		}
 		
@@ -315,7 +314,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 
 		double res = value() * val.double_value();
 
-		return ResultSequenceFactory.create_new(new XSDayTimeDuration(res));
+		return new XSDayTimeDuration(res);
 	}
 
 	/**
@@ -356,8 +355,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 				throw DynamicError.overflowUnderflow();
 			}
 
-			return ResultSequenceFactory
-					.create_new(new XSDayTimeDuration(retval));
+			return new XSDayTimeDuration(retval);
 		} else if (at instanceof XSDecimal) {
 			XSDecimal dt = (XSDecimal) at;
 			
@@ -370,8 +368,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 				throw DynamicError.overflowUnderflow();
 			}
 			
-			return ResultSequenceFactory.create_new(new XSDayTimeDuration(
-					ret.intValue()));	
+			return new XSDayTimeDuration(ret.intValue());
 		} else if (at instanceof XSDayTimeDuration) {
 			XSDuration md = (XSDuration) at;
 
@@ -380,7 +377,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 			BigDecimal l = new BigDecimal(md.value());
 			res = res.divide(l, 18, BigDecimal.ROUND_HALF_EVEN);
 
-			return ResultSequenceFactory.create_new(new XSDecimal(res));
+			return new XSDecimal(res);
 		} else {
 			DynamicError.throw_type_error();
 			return null; // unreach

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
@@ -30,7 +30,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -229,9 +228,7 @@ public class XSDecimal extends NumericType {
 	public boolean eq(AnyType at, DynamicContext dynamicContext) throws DynamicError {
 		XSDecimal dt = null;
 		if (!(at instanceof XSDecimal)) { 
-			ResultSequence rs = ResultSequenceFactory.create_new(at);
-			
-			ResultSequence crs = constructor(rs);
+			ResultSequence crs = constructor(at);
 			if (crs.empty()) {
 				throw DynamicError.throw_type_error();
 			}
@@ -262,8 +259,7 @@ public class XSDecimal extends NumericType {
 	}
 
 	protected Item convertArg(AnyType arg) throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new(arg);
-		rs = constructor(rs);
+		ResultSequence rs = constructor(arg);
 		Item carg = rs.first();
 		return carg;
 	}
@@ -303,7 +299,7 @@ public class XSDecimal extends NumericType {
 		XSDecimal dt = (XSDecimal) at;
 
 		// own it
-		return ResultSequenceFactory.create_new(new XSDecimal(_value.add(dt.getValue())));
+		return new XSDecimal(_value.add(dt.getValue()));
 	}
 	
 	private ResultSequence convertResultSequence(ResultSequence arg)
@@ -339,7 +335,7 @@ public class XSDecimal extends NumericType {
 			DynamicError.throw_type_error();
 		XSDecimal dt = (XSDecimal) at;
 
-		return ResultSequenceFactory.create_new(new XSDecimal(_value.subtract(dt.getValue())));
+		return new XSDecimal(_value.subtract(dt.getValue()));
 	}
 
 	/**
@@ -356,7 +352,7 @@ public class XSDecimal extends NumericType {
 
 		XSDecimal val = (XSDecimal) get_single_type(carg, XSDecimal.class);
 		BigDecimal result = _value.multiply(val.getValue());
-		return ResultSequenceFactory.create_new(new XSDecimal(result));
+		return new XSDecimal(result);
 	}
 
 	/**
@@ -376,7 +372,7 @@ public class XSDecimal extends NumericType {
 			throw DynamicError.div_zero(null);
 		}
 		BigDecimal result = getValue().divide(val.getValue(), 18, BigDecimal.ROUND_HALF_EVEN);
-		return ResultSequenceFactory.create_new(new XSDecimal(result));
+		return new XSDecimal(result);
 	}
 
 	/**
@@ -399,8 +395,7 @@ public class XSDecimal extends NumericType {
 		BigInteger _ivalue = _value.toBigInteger();
 		BigInteger ival =  val.getValue().toBigInteger();
 		BigInteger result = _ivalue.divide(ival);
-		return ResultSequenceFactory.create_new(new 
-				           XSInteger(result));
+		return new XSInteger(result);
 	}
 
 	/**
@@ -420,7 +415,7 @@ public class XSDecimal extends NumericType {
 		// BigDecimal result = _value.remainder(val.getValue());
 		BigDecimal result = remainder(_value, val.getValue()); 
 		
-		return ResultSequenceFactory.create_new(new XSDecimal(result));
+		return new XSDecimal(result);
 	}
 
 	public static BigDecimal remainder(BigDecimal value, BigDecimal divisor) {
@@ -440,7 +435,7 @@ public class XSDecimal extends NumericType {
 	 */
 	public ResultSequence unary_minus() {
 		BigDecimal result = _value.negate();
-		return ResultSequenceFactory.create_new(new XSDecimal(result));
+		return new XSDecimal(result);
 	}
 
 	// functions

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
@@ -27,7 +27,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -254,8 +253,7 @@ public class XSDouble extends NumericType {
 	 * @since 1.1
 	 */
 	public boolean eq(AnyType aa, DynamicContext dynamicContext) throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new(aa);
-		ResultSequence crs = constructor(rs);
+		ResultSequence crs = constructor(aa);
 		
 		if (crs.empty()) {
 			throw DynamicError.throw_type_error();
@@ -290,8 +288,7 @@ public class XSDouble extends NumericType {
 	}
 
 	protected Item convertArg(AnyType arg) throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new(arg);
-		rs = constructor(rs);
+		ResultSequence rs = constructor(arg);
 		Item carg = rs.first();
 		return carg;
 	}
@@ -331,8 +328,7 @@ public class XSDouble extends NumericType {
 			DynamicError.throw_type_error();
 		XSDouble val = (XSDouble) at;
 
-		return ResultSequenceFactory.create_new(new XSDouble(double_value()
-				+ val.double_value()));
+		return new XSDouble(double_value() + val.double_value());
 	}
 
 	private ResultSequence convertResultSequence(ResultSequence arg)
@@ -365,8 +361,7 @@ public class XSDouble extends NumericType {
 		
 		XSDouble val = (XSDouble) get_single_type(carg, XSDouble.class);
 
-		return ResultSequenceFactory.create_new(new XSDouble(double_value()
-				- val.double_value()));
+		return new XSDouble(double_value() - val.double_value());
 	}
 
 	/**
@@ -383,8 +378,7 @@ public class XSDouble extends NumericType {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = (XSDouble) get_single_type(carg, XSDouble.class);
-		return ResultSequenceFactory.create_new(new XSDouble(double_value()
-				* val.double_value()));
+		return new XSDouble(double_value() * val.double_value());
 	}
 
 	/**
@@ -399,8 +393,7 @@ public class XSDouble extends NumericType {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = (XSDouble) get_single_type(carg, XSDouble.class);
-		return ResultSequenceFactory.create_new(new XSDouble(double_value()
-				/ val.double_value()));
+		return new XSDouble(double_value() / val.double_value());
 	}
 
 	/**
@@ -427,7 +420,7 @@ public class XSDouble extends NumericType {
 			throw DynamicError.div_zero(null);
 
 		BigDecimal result = new BigDecimal((double_value() / val.double_value()));
-		return ResultSequenceFactory.create_new(new XSInteger(result.toBigInteger()));
+		return new XSInteger(result.toBigInteger());
 	}
 
 	/**
@@ -442,8 +435,7 @@ public class XSDouble extends NumericType {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = (XSDouble) get_single_type(carg, XSDouble.class);
-		return ResultSequenceFactory.create_new(new XSDouble(double_value()
-				% val.double_value()));
+		return new XSDouble(double_value() % val.double_value());
 	}
 
 	/**
@@ -452,8 +444,7 @@ public class XSDouble extends NumericType {
 	 * @return A XSDouble representing the negation of this XSDecimal
 	 */
 	public ResultSequence unary_minus() {
-		return ResultSequenceFactory.create_new(new XSDouble(-1
-				* double_value()));
+		return new XSDouble(-1 * double_value());
 	}
 
 	// functions

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
@@ -27,7 +27,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -279,8 +278,7 @@ public class XSFloat extends NumericType {
 			DynamicError.throw_type_error();
 		XSFloat val = (XSFloat) at;
 
-		return ResultSequenceFactory.create_new(new XSFloat(float_value()
-				+ val.float_value()));
+		return new XSFloat(float_value() + val.float_value());
 	}
 
 	/**
@@ -299,8 +297,7 @@ public class XSFloat extends NumericType {
 			DynamicError.throw_type_error();
 		XSFloat val = (XSFloat) at;
 
-		return ResultSequenceFactory.create_new(new XSFloat(float_value()
-				- val.float_value()));
+		return new XSFloat(float_value() - val.float_value());
 	}
 
 	/**
@@ -315,8 +312,7 @@ public class XSFloat extends NumericType {
 	public ResultSequence times(ResultSequence arg) throws DynamicError {
 		ResultSequence carg = constructor(arg);
 		XSFloat val = (XSFloat) get_single_type(carg, XSFloat.class);
-		return ResultSequenceFactory.create_new(new XSFloat(float_value()
-				* val.float_value()));
+		return new XSFloat(float_value() * val.float_value());
 	}
 
 	/**
@@ -330,8 +326,7 @@ public class XSFloat extends NumericType {
 	public ResultSequence div(ResultSequence arg) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSFloat val = (XSFloat) get_single_type(carg, XSFloat.class);
-		return ResultSequenceFactory.create_new(new XSFloat(float_value()
-				/ val.float_value()));
+		return new XSFloat(float_value() / val.float_value());
 	}
 
 	/**
@@ -358,7 +353,7 @@ public class XSFloat extends NumericType {
 
 		BigDecimal result = BigDecimal.valueOf((new Float((float_value() / 
 				                                 val.float_value()))).longValue());
-		return ResultSequenceFactory.create_new(new XSInteger(result.toBigInteger()));
+		return new XSInteger(result.toBigInteger());
 	}
 
 	/**
@@ -373,8 +368,7 @@ public class XSFloat extends NumericType {
 	public ResultSequence mod(ResultSequence arg) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSFloat val = (XSFloat) get_single_type(carg, XSFloat.class);
-		return ResultSequenceFactory.create_new(new XSFloat(float_value()
-				% val.float_value()));
+		return new XSFloat(float_value() % val.float_value());
 	}
 
 	/**
@@ -383,8 +377,7 @@ public class XSFloat extends NumericType {
 	 * @return A XSFloat representing the negation of the number stored
 	 */
 	public ResultSequence unary_minus() {
-		return ResultSequenceFactory
-				.create_new(new XSFloat(-1 * float_value()));
+		return new XSFloat(-1 * float_value());
 	}
 
 	/**
@@ -449,8 +442,7 @@ public class XSFloat extends NumericType {
 	}
 	
 	protected Item convertArg(AnyType arg) throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new(arg);
-		rs = constructor(rs);
+		ResultSequence rs = constructor(arg);
 		Item carg = rs.first();
 		return carg;
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
@@ -28,7 +28,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -227,8 +226,7 @@ public class XSInteger extends XSDecimal {
 		
 		XSInteger val = (XSInteger)at;
 
-		return ResultSequenceFactory.create_new(new 
-				                   XSInteger(int_value().add(val.int_value())));
+		return new XSInteger(int_value().add(val.int_value()));
 		
 	}
 
@@ -261,8 +259,7 @@ public class XSInteger extends XSDecimal {
 		ResultSequence carg = convertResultSequence(arg);
 		XSInteger val = (XSInteger) get_single_type(carg, XSInteger.class);
 		
-		return ResultSequenceFactory.create_new(new 
-				                 XSInteger(int_value().subtract(val.int_value())));
+		return new XSInteger(int_value().subtract(val.int_value()));
 	}
 
 	/**
@@ -279,8 +276,7 @@ public class XSInteger extends XSDecimal {
 
 		XSInteger val = (XSInteger) get_single_type(carg, XSInteger.class);
 		
-		return ResultSequenceFactory.create_new(new 
-				                 XSInteger(int_value().multiply(val.int_value())));
+		return new XSInteger(int_value().multiply(val.int_value()));
 	}
 
 	/**
@@ -297,7 +293,7 @@ public class XSInteger extends XSDecimal {
 		XSInteger val = (XSInteger) get_single_type(carg, XSInteger.class);
 		BigInteger result = int_value().remainder(val.int_value()); 
 		
-		return ResultSequenceFactory.create_new(new XSInteger(result));
+		return new XSInteger(result);
 	}
 
 	/**
@@ -306,8 +302,7 @@ public class XSInteger extends XSDecimal {
 	 * @return New XSInteger representing the negation of the integer stored
 	 */
 	public ResultSequence unary_minus() {
-		return ResultSequenceFactory
-				.create_new(new XSInteger(int_value().multiply(BigInteger.valueOf(-1))));
+		return new XSInteger(int_value().multiply(BigInteger.valueOf(-1)));
 	}
 
 	/**
@@ -333,8 +328,7 @@ public class XSInteger extends XSDecimal {
 	}
 	
 	protected Item convertArg(AnyType arg) throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new(arg);
-		rs = constructor(rs);
+		ResultSequence rs = constructor(arg);
 		Item carg = rs.first();
 		return carg;
 	}
@@ -362,7 +356,7 @@ public class XSInteger extends XSDecimal {
 		}
 		
 		BigDecimal result = getValue().divide(val.getValue(), 18, BigDecimal.ROUND_HALF_EVEN);
-		return ResultSequenceFactory.create_new(new XSDecimal(result));
+		return new XSDecimal(result);
 	}
 
 	public TypeDefinition getTypeDefinition() {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
@@ -30,7 +30,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
@@ -403,7 +402,7 @@ Cloneable {
 		xmlCal.add(dtduration.negate());
 		res = new XSTime(xmlCal.toGregorianCalendar(), res.tz());
 
-		return ResultSequenceFactory.create_new(res);
+		return res;
 	}
 
 	private ResultSequence minusXSTimeDuration(Item at) {
@@ -413,7 +412,7 @@ Cloneable {
 		Calendar thatCal = normalizeCalendar(val.calendar(), val.tz());
 		long duration = thisCal.getTimeInMillis() - thatCal.getTimeInMillis();
 		dtduration = _datatypeFactory.newDuration(duration);
-		return ResultSequenceFactory.create_new(XSDayTimeDuration.parseDTDuration(dtduration.toString()));
+		return XSDayTimeDuration.parseDTDuration(dtduration.toString());
 	}
 
 	/**
@@ -437,7 +436,7 @@ Cloneable {
 
 			res.calendar().add(Calendar.MILLISECOND, (int) ms);
 
-			return ResultSequenceFactory.create_new(res);
+			return res;
 		} catch (CloneNotSupportedException err) {
 			assert false;
 			return null;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
@@ -24,7 +24,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
@@ -347,7 +346,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 
 		int res = monthValue() + val.monthValue();
 
-		return ResultSequenceFactory.create_new(new XSYearMonthDuration(res));
+		return new XSYearMonthDuration(res);
 	}
 
 	/**
@@ -366,7 +365,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 
 		int res = monthValue() - val.monthValue();
 
-		return ResultSequenceFactory.create_new(new XSYearMonthDuration(res));
+		return new XSYearMonthDuration(res);
 	}
 
 	/**
@@ -384,7 +383,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 		if (arg.size() == 1) {
 			Item argValue = arg.first();
             if (argValue instanceof XSDecimal) {
-            	convertedRS = ResultSequenceFactory.create_new(new XSDouble(argValue.getStringValue()));	
+            	convertedRS = new XSDouble(argValue.getStringValue());
             }
 		}
 		
@@ -401,7 +400,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 		
 		int res = (int) Math.round(monthValue() * val.double_value());
 
-		return ResultSequenceFactory.create_new(new XSYearMonthDuration(res));
+		return new XSYearMonthDuration(res);
 	}
 
 	/**
@@ -428,8 +427,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 			if (!dt.zero())
 				ret = (int) Math.round(monthValue() / dt.double_value());
 
-			return ResultSequenceFactory.create_new(new XSYearMonthDuration(
-					ret));
+			return new XSYearMonthDuration(ret);
 		} else if (at instanceof XSDecimal) {
 			XSDecimal dt = (XSDecimal) at;
 			
@@ -438,14 +436,13 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 			if (!dt.zero())
 				ret = (int) Math.round(monthValue() / dt.getValue().doubleValue());
 			
-			return ResultSequenceFactory.create_new(new XSYearMonthDuration(
-					ret));	
+			return new XSYearMonthDuration(ret);	
 		} else if (at instanceof XSYearMonthDuration) {
 			XSYearMonthDuration md = (XSYearMonthDuration) at;
 
 			double res = (double) monthValue() / md.monthValue();
 
-			return ResultSequenceFactory.create_new(new XSDecimal(new BigDecimal(res)));
+			return new XSDecimal(new BigDecimal(res));
 		} else {
 			DynamicError.throw_type_error();
 			return null; // unreach


### PR DESCRIPTION
- Use `ResultBuffer.EMPTY` instead of `ResultSequenceFactory.create_new()`
- Remove unnecessary calls to `ResultSequenceFactory.create_new`
- Use `XSBoolean` more efficiently
