### PR TITLE
API usage and build warnings

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DOMLoaderException.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DOMLoaderException.java
@@ -14,9 +14,7 @@ package org.eclipse.wst.xml.xpath2.processor;
 
 /**
  * Exception caused by DOM loader.
- * @deprecated Only used in deprecated APIs
  */
-@Deprecated
 public class DOMLoaderException extends XPathException {
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
@@ -58,6 +58,7 @@ import org.w3c.dom.Node;
  * Initializes and provides functionality of a dynamic context according to the
  * XPath 2.0 specification.
  */
+@Deprecated
 public class DefaultDynamicContext extends DefaultStaticContext implements
 		DynamicContext {
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
@@ -229,7 +229,7 @@ public class DefaultDynamicContext extends DefaultStaticContext implements
 	 */
 	public void add_function_library(FunctionLibrary fl) {
 		super.add_function_library(fl);
-		fl.set_dynamic_context(this);
+		fl.set_dynamic_context(new DynamicContextAdapter(this));
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
@@ -238,7 +238,7 @@ public class DefaultDynamicContext extends DefaultStaticContext implements
 	 * @since 1.1
 	 */
 	public ResultSequence get_doc(URI resolved) {
-		Document doc = null;
+		Document doc;
 		if (_loaded_documents.containsKey(resolved)) {
 			 //tried before
 			doc = _loaded_documents.get(resolved);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultDynamicContext.java
@@ -36,7 +36,6 @@ import java.util.TimeZone;
 import org.apache.xerces.xs.XSModel;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
-import org.eclipse.wst.xml.xpath2.processor.internal.DefaultStaticContext;
 import org.eclipse.wst.xml.xpath2.processor.internal.DynamicContextAdapter;
 import org.eclipse.wst.xml.xpath2.processor.internal.Focus;
 import org.eclipse.wst.xml.xpath2.processor.internal.StaticContextAdapter;
@@ -59,7 +58,7 @@ import org.w3c.dom.Node;
  * XPath 2.0 specification.
  */
 @Deprecated
-public class DefaultDynamicContext extends DefaultStaticContext implements
+public class DefaultDynamicContext extends org.eclipse.wst.xml.xpath2.processor.internal.DefaultStaticContext implements
 		DynamicContext {
 
 	private Focus _focus;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -38,7 +38,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.StaticContext;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.Axis;
 import org.eclipse.wst.xml.xpath2.processor.internal.DescendantOrSelfAxis;
 import org.eclipse.wst.xml.xpath2.processor.internal.DynamicContextAdapter;
@@ -362,7 +361,8 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	 *            is the xpath.
 	 * @return result sequence.
 	 */
-	public ResultSequence visit(XPath xp) {
+	@SuppressWarnings("deprecation")
+	public ResultSequence visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp) {
 		ResultSequence rs = do_expr(xp.iterator());
 
 		return rs;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -206,6 +206,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 		return nodeTd != null && nodeTd.derivedFromType(td, method);
 	}
 
+	@Deprecated
 	public DefaultEvaluator(org.eclipse.wst.xml.xpath2.processor.DynamicContext dynamicContext, Document doc) {
 		this(new StaticContextAdapter(dynamicContext), new DynamicContextAdapter(dynamicContext));
 		
@@ -313,6 +314,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	 *             error.
 	 * @return result sequence.
 	 */
+	@Deprecated
 	public org.eclipse.wst.xml.xpath2.processor.ResultSequence evaluate(XPathNode node) {
 		return ResultSequenceUtil.newToOld(evaluate2(node));
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -981,7 +981,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	 * @return a new function
 	 */
 	public ResultSequence visit(CastableExpr cexp) {
-		boolean castable = false;
+		boolean castable;
 		try {
 			CastExpr ce = new CastExpr((Expr) cexp.left(), (SingleType) cexp
 					.right());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/Engine.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/Engine.java
@@ -4,7 +4,6 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.StaticContext;
 import org.eclipse.wst.xml.xpath2.api.XPath2Engine;
 import org.eclipse.wst.xml.xpath2.api.XPath2Expression;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.FnBoolean;
 
 /**
@@ -13,8 +12,8 @@ import org.eclipse.wst.xml.xpath2.processor.internal.function.FnBoolean;
 public class Engine implements XPath2Engine {
 
 	public XPath2Expression parseExpression(String expression, StaticContext context) {
-
-		XPath xPath = new JFlexCupParser().parse(expression);
+		@SuppressWarnings("deprecation")
+		org.eclipse.wst.xml.xpath2.processor.ast.XPath xPath = new JFlexCupParser().parse(expression);
 		xPath.setStaticContext(context);
 		StaticNameResolver name_check = new StaticNameResolver(context);
 		name_check.check(xPath);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/Evaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/Evaluator.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor;
 
+import org.eclipse.wst.xml.xpath2.api.XPath2Expression;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.*;
 
 /**
@@ -26,6 +27,9 @@ public interface Evaluator {
 	 * @throws DynamicError
 	 *             dynamic error.
 	 * @return Result of evaluation.
+	 *
+	 * @deprecated Use {@link XPath2Expression#evaluate} instead.
 	 */
+	@Deprecated
 	public ResultSequence evaluate(XPathNode root) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/JFlexCupParser.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/JFlexCupParser.java
@@ -12,7 +12,6 @@
 
 package org.eclipse.wst.xml.xpath2.processor;
 
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.InternalXPathParser;
 
 /**
@@ -28,7 +27,8 @@ public class JFlexCupParser implements XPathParser {
 	 * @throws XPathParserException.
 	 * @return the xpath value.
 	 */
-	public XPath parse(String xpath) throws XPathParserException {
+	@SuppressWarnings("deprecation")
+	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath) throws XPathParserException {
 
 		return new InternalXPathParser().parse(xpath, false);
 	}
@@ -44,7 +44,8 @@ public class JFlexCupParser implements XPathParser {
 	 * @return the xpath value.
 	 * @since 2.0
 	 */
-	public XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException {
+	@SuppressWarnings("deprecation")
+	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException {
 
 		return new InternalXPathParser().parse(xpath, isRootlessAccess);
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/ResultSequenceFactory.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/ResultSequenceFactory.java
@@ -11,12 +11,16 @@
 
 package org.eclipse.wst.xml.xpath2.processor;
 
+import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.processor.internal.DefaultRSFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.*;
 
 /**
  * Result sequence factory
+ *
+ * @deprecated Use {@link ResultBuffer} instead.
  */
+@Deprecated
 public abstract class ResultSequenceFactory {
 	private static final ResultSequenceFactory _factory = new DefaultRSFactory();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
@@ -977,10 +977,6 @@ public class StaticNameResolver implements XPathVisitor<Void>, StaticChecker {
 	 * @return null.
 	 */
 	public Void visit(PITest e) {
-		String arg = e.arg();
-		if (arg == null)
-			arg = "";
-
 		return null;
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import javax.xml.XMLConstants;
 
 import org.eclipse.wst.xml.xpath2.api.Function;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.ReverseAxis;
 import org.eclipse.wst.xml.xpath2.processor.internal.StaticAttrNameError;
 import org.eclipse.wst.xml.xpath2.processor.internal.StaticContextAdapter;
@@ -288,7 +287,8 @@ public class StaticNameResolver implements XPathVisitor<Void>, StaticChecker {
 	 *            is the XPath.
 	 * @return null.
 	 */
-	public Void visit(XPath xp) {
+	@SuppressWarnings("deprecation")
+	public Void visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp) {
 		for (Iterator<Expr> i = xp.iterator(); i.hasNext();) {
 			Expr e = i.next();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/StaticNameResolver.java
@@ -119,6 +119,7 @@ public class StaticNameResolver implements XPathVisitor<Void>, StaticChecker {
 	 *            is the static context.
 	 * @since 2.0
 	 */
+	@Deprecated
 	public StaticNameResolver(final org.eclipse.wst.xml.xpath2.processor.StaticContext sc) {
 		_sc = new StaticContextAdapter(sc);
 		_err = null;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/XPathParser.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/XPathParser.java
@@ -12,8 +12,6 @@
 
 package org.eclipse.wst.xml.xpath2.processor;
 
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
-
 /**
  * This is an interface class for the XPath parser.
  */
@@ -28,7 +26,8 @@ public interface XPathParser {
 	 *             XPath parser exception.
 	 * @return The parsed XPath.
 	 */
-	public XPath parse(String xpath) throws XPathParserException;
+	@SuppressWarnings("deprecation")
+	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath) throws XPathParserException;
 	
 	/**
 	 * Constructor for the XPath parser interface.
@@ -42,5 +41,6 @@ public interface XPathParser {
 	 * @return The parsed XPath.
 	 * @since 2.0
 	 */
-	public XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException;
+	@SuppressWarnings("deprecation")
+	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultRSFactory.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultRSFactory.java
@@ -12,20 +12,17 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal;
 
-import org.eclipse.wst.xml.xpath2.processor.ResultSequence;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
-
 /**
  * Factory implementation which creates sequences of type DefaultResultSequence.
  * 
  */
 @Deprecated
-public class DefaultRSFactory extends ResultSequenceFactory {
-	private static final ResultSequence _rs_creator = new DefaultResultSequence();
+public class DefaultRSFactory extends org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory {
+	private static final org.eclipse.wst.xml.xpath2.processor.ResultSequence _rs_creator = new DefaultResultSequence();
 
 	public static final int POOL_SIZE = 50;
 
-	private ResultSequence[] _rs_pool = new ResultSequence[POOL_SIZE];
+	private org.eclipse.wst.xml.xpath2.processor.ResultSequence[] _rs_pool = new org.eclipse.wst.xml.xpath2.processor.ResultSequence[POOL_SIZE];
 	private int _head_pos;
 
 	/**
@@ -39,7 +36,7 @@ public class DefaultRSFactory extends ResultSequenceFactory {
 		_head_pos = POOL_SIZE - 1;
 	}
 
-	protected ResultSequence fact_create_new() {
+	protected org.eclipse.wst.xml.xpath2.processor.ResultSequence fact_create_new() {
 		if (_head_pos > 0) {
 			return _rs_pool[_head_pos--];
 		}
@@ -47,7 +44,7 @@ public class DefaultRSFactory extends ResultSequenceFactory {
 		return _rs_creator.create_new();
 	}
 
-	protected void fact_release(ResultSequence rs) {
+	protected void fact_release(org.eclipse.wst.xml.xpath2.processor.ResultSequence rs) {
 		int new_pos = _head_pos + 1;
 
 		if (new_pos < POOL_SIZE) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultRSFactory.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultRSFactory.java
@@ -19,6 +19,7 @@ import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
  * Factory implementation which creates sequences of type DefaultResultSequence.
  * 
  */
+@Deprecated
 public class DefaultRSFactory extends ResultSequenceFactory {
 	private static final ResultSequence _rs_creator = new DefaultResultSequence();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultResultSequence.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultResultSequence.java
@@ -21,7 +21,6 @@ import java.util.ListIterator;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.typesystem.ItemType;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.SimpleAtomicItemTypeImpl;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
@@ -31,7 +30,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLi
  * @deprecated use {@link ResultBuffer} instead
  */
 @Deprecated
-public class DefaultResultSequence extends ResultSequence {
+public class DefaultResultSequence extends org.eclipse.wst.xml.xpath2.processor.ResultSequence {
 
 	private List<Item> _seq;
 
@@ -66,7 +65,7 @@ public class DefaultResultSequence extends ResultSequence {
 	 * @param rs
 	 *            ResultSequence
 	 */
-	public void concat(ResultSequence rs) {
+	public void concat(org.eclipse.wst.xml.xpath2.processor.ResultSequence rs) {
 		for (Iterator<Item> i = rs.iterator(); i.hasNext();)
 			_seq.add(i.next());
 	}
@@ -136,7 +135,7 @@ public class DefaultResultSequence extends ResultSequence {
 	 * 
 	 * @return The new sequence.
 	 */
-	public ResultSequence create_new() {
+	public org.eclipse.wst.xml.xpath2.processor.ResultSequence create_new() {
 		return new DefaultResultSequence();
 	}
 	

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
@@ -204,7 +204,7 @@ public class DefaultStaticContext implements StaticContext {
 	 *            Function library to add.
 	 */
 	public void add_function_library(FunctionLibrary fl) {
-		fl.set_static_context(this);
+		fl.set_static_context(new StaticContextAdapter(this));
 		_functions.put(fl.namespace(), fl);
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
@@ -15,11 +15,11 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
@@ -92,7 +92,7 @@ public class DefaultStaticContext implements StaticContext {
 	// or in more human terms:
 	// a stack of scopes each containing a symbol table
 	// XXX vars contain AnyType... should they be ResultSequence ?
-	private Stack<Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence>> _scopes;
+	private ArrayList<Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence>> _scopes;
 
 	/**
 	 * Constructor.
@@ -113,7 +113,7 @@ public class DefaultStaticContext implements StaticContext {
 
 		_cntxt_item_type = null;
 
-		_scopes = new Stack<Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence>>();
+		_scopes = new ArrayList<Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence>>();
 		new_scope();
 
 		if (_model != null)
@@ -486,18 +486,18 @@ public class DefaultStaticContext implements StaticContext {
 	public void new_scope() {
 		Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence> vars = new HashMap<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence>();
 
-		_scopes.push(vars);
+		_scopes.add(vars);
 	}
 
 	/**
 	 * Destroys a scope.
 	 */
 	public void destroy_scope() {
-		_scopes.pop();
+		_scopes.remove(_scopes.size() - 1);
 	}
 
 	private Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence> current_scope() {
-		return _scopes.peek();
+		return _scopes.get(_scopes.size() - 1);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
@@ -42,6 +42,7 @@ import org.w3c.dom.Node;
  * Default implementation of a static context as described by the XPath 2.0
  * specification.
  */
+@Deprecated
 public class DefaultStaticContext implements StaticContext {
 
 	private boolean _xpath1_compatible;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultStaticContext.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequence;
-import org.eclipse.wst.xml.xpath2.processor.StaticContext;
 import org.eclipse.wst.xml.xpath2.processor.function.FnFunctionLibrary;
 import org.eclipse.wst.xml.xpath2.processor.function.XSCtrLibrary;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.ConstructorFL;
@@ -43,7 +41,7 @@ import org.w3c.dom.Node;
  * specification.
  */
 @Deprecated
-public class DefaultStaticContext implements StaticContext {
+public class DefaultStaticContext implements org.eclipse.wst.xml.xpath2.processor.StaticContext {
 
 	private boolean _xpath1_compatible;
 	private String _default_namespace;
@@ -554,7 +552,7 @@ public class DefaultStaticContext implements StaticContext {
 	/*
 	 * Set a XPath2 sequence into a variable.
 	 */
-	protected void set_variable(QName var, ResultSequence val) {
+	protected void set_variable(QName var, org.eclipse.wst.xml.xpath2.processor.ResultSequence val) {
 		Map<QName, org.eclipse.wst.xml.xpath2.api.ResultSequence> scope = current_scope();
 
 		scope.put(var, val);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultVisitor.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DefaultVisitor.java
@@ -14,7 +14,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AddExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AndExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AnyKindTest;
@@ -77,7 +76,8 @@ public class DefaultVisitor implements XPathVisitor<Object> {
 	 *            is the xpath expression.
 	 * @return the xpath expressions.
 	 */
-	public Object visit(XPath xp) {
+	@SuppressWarnings("deprecation")
+	public Object visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp) {
 		for (Iterator<Expr> i = xp.iterator(); i.hasNext();) {
 			Expr e = i.next();
 			e.accept(this);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
@@ -25,6 +25,7 @@ public class DynamicContextAdapter implements
 	private final org.eclipse.wst.xml.xpath2.processor.DynamicContext dc;
 	private StaticContextAdapter sca;
 
+	@Deprecated
 	public DynamicContextAdapter(
 			org.eclipse.wst.xml.xpath2.processor.DynamicContext dc) {
 		this.dc = dc;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
@@ -61,9 +61,9 @@ public class DynamicContextAdapter implements
 	}
 
 	public Document getDocument(URI uri) {
-		org.eclipse.wst.xml.xpath2.processor.ResultSequence rs = dc.get_doc(uri);
+		ResultSequence rs = dc.get_doc(uri);
 		if (rs == null || rs.empty()) return null;
-		return ((DocType)(rs.get(0))).value();
+		return ((DocType)(rs.item(0))).value();
 	}
 
 	public Map<String, List<Document>> getCollections() {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/DynamicContextAdapter.java
@@ -22,6 +22,7 @@ import org.w3c.dom.Node;
 
 public class DynamicContextAdapter implements
 		org.eclipse.wst.xml.xpath2.api.DynamicContext {
+	@SuppressWarnings("deprecation")
 	private final org.eclipse.wst.xml.xpath2.processor.DynamicContext dc;
 	private StaticContextAdapter sca;
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/ExpressionPrinterVisitor.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/ExpressionPrinterVisitor.java
@@ -8,7 +8,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AddExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AndExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AnyKindTest;
@@ -71,7 +70,8 @@ public class ExpressionPrinterVisitor implements XPathVisitor<String> {
     public static final ExpressionPrinterVisitor DEFAULT = new ExpressionPrinterVisitor();
 
     @Override
-    public String visit(XPath xp) {
+    @SuppressWarnings("deprecation")
+    public String visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp) {
         StringBuilder builder = new StringBuilder();
         boolean first = true;
         for (Iterator<Expr> exprIt = xp.iterator(); exprIt.hasNext(); ) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/InternalXPathParser.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/InternalXPathParser.java
@@ -18,7 +18,6 @@ import java_cup.runtime.Symbol;
 
 import org.eclipse.wst.xml.xpath2.processor.StaticError;
 import org.eclipse.wst.xml.xpath2.processor.XPathParserException;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.XPathExpr;
 
 /**
@@ -38,14 +37,14 @@ public class InternalXPathParser {
 	 * @return the xpath value.
 	 * @since 2.0
 	 */
-	public XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException {
+	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException {
 
 		XPathFlex lexer = new XPathFlex(new StringReader(xpath));
 
 		try {
 			XPathCup p = new XPathCup(lexer); 
 			Symbol res = p.parse();
-			XPath xPath2 = (XPath) res.value;
+			org.eclipse.wst.xml.xpath2.processor.ast.XPath xPath2 = (org.eclipse.wst.xml.xpath2.processor.ast.XPath) res.value;
 			if (isRootlessAccess) {
 				xPath2.accept(new DefaultVisitor() {
 					public Object visit(XPathExpr e) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/InternalXPathParser.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/InternalXPathParser.java
@@ -23,7 +23,6 @@ import org.eclipse.wst.xml.xpath2.processor.internal.ast.XPathExpr;
 /**
  * JFlexCupParser parses the xpath expression
  */
-@SuppressWarnings("deprecation")
 public class InternalXPathParser {
 
 	/**
@@ -37,6 +36,7 @@ public class InternalXPathParser {
 	 * @return the xpath value.
 	 * @since 2.0
 	 */
+	@SuppressWarnings("deprecation")
 	public org.eclipse.wst.xml.xpath2.processor.ast.XPath parse(String xpath, boolean isRootlessAccess) throws XPathParserException {
 
 		XPathFlex lexer = new XPathFlex(new StringReader(xpath));

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
@@ -85,8 +85,6 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 // XXX currently not supported anymore!
 public class Normalizer implements XPathVisitor<XPathNode> {
 
-	private org.eclipse.wst.xml.xpath2.processor.StaticContext _sc;
-
 	/**
 	 * Static Context is set to sc
 	 * 
@@ -95,7 +93,6 @@ public class Normalizer implements XPathVisitor<XPathNode> {
 	 */
 	@Deprecated
 	public Normalizer(org.eclipse.wst.xml.xpath2.processor.StaticContext sc) {
-		_sc = sc;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
@@ -17,7 +17,6 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.processor.StaticContext;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.function.FnFunctionLibrary;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AddExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AndExpr;
@@ -106,7 +105,8 @@ public class Normalizer implements XPathVisitor<XPathNode> {
 	 *            is the xpath expression.
 	 * @return the xpath expressions.
 	 */
-	public XPathNode visit(XPath xp) {
+	@SuppressWarnings("deprecation")
+	public XPathNode visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp) {
 		Collection<Expr> exprs = new ArrayList<Expr>();
 
 		for (Iterator<Expr> i = xp.iterator(); i.hasNext();) {
@@ -117,7 +117,7 @@ public class Normalizer implements XPathVisitor<XPathNode> {
 			exprs.add(n);
 		}
 
-		return new XPath(exprs);
+		return new org.eclipse.wst.xml.xpath2.processor.ast.XPath(exprs);
 	}
 
 	private void printVarExprPairs(Iterator<VarExprPair> i) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/Normalizer.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.processor.StaticContext;
 import org.eclipse.wst.xml.xpath2.processor.function.FnFunctionLibrary;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AddExpr;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.AndExpr;
@@ -86,7 +85,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 // XXX currently not supported anymore!
 public class Normalizer implements XPathVisitor<XPathNode> {
 
-	private StaticContext _sc;
+	private org.eclipse.wst.xml.xpath2.processor.StaticContext _sc;
 
 	/**
 	 * Static Context is set to sc
@@ -94,7 +93,8 @@ public class Normalizer implements XPathVisitor<XPathNode> {
 	 * @param sc
 	 *            is the StaticContext.
 	 */
-	public Normalizer(StaticContext sc) {
+	@Deprecated
+	public Normalizer(org.eclipse.wst.xml.xpath2.processor.StaticContext sc) {
 		_sc = sc;
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
@@ -151,9 +151,9 @@ public class StaticContextAdapter implements
 
 	public Function resolveFunction(javax.xml.namespace.QName name, int arity) {
 		if (sc.function_exists(new QName(name), arity)) {
-			if (sc instanceof DefaultStaticContext) {
-				DefaultStaticContext dc = (DefaultStaticContext)sc;
-				return dc.function(new QName(name), arity);
+			FunctionLibrary functionLibrary = getFunctionLibraries().get(name.getNamespaceURI());
+			if (functionLibrary != null) {
+				return functionLibrary.resolveFunction(name.getLocalPart(), arity);
 			}
 		}
 		throw new IllegalArgumentException("Function not found "+name);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
@@ -40,6 +40,7 @@ import org.w3c.dom.Node;
 
 public class StaticContextAdapter implements
 		org.eclipse.wst.xml.xpath2.api.StaticContext {
+	@SuppressWarnings("deprecation")
 	private final org.eclipse.wst.xml.xpath2.processor.StaticContext sc;
 
 	@Deprecated
@@ -73,6 +74,7 @@ public class StaticContextAdapter implements
 		return BuiltinTypeLibrary.XS_UNTYPED;
 	}
 
+	@SuppressWarnings("deprecation")
 	public Map<String, FunctionLibrary> getFunctionLibraries() {
 		if (sc instanceof DefaultStaticContext) {
 			DefaultStaticContext dsc = (DefaultStaticContext)sc;
@@ -81,6 +83,7 @@ public class StaticContextAdapter implements
 		return Collections.emptyMap();
 	}
 
+	@SuppressWarnings("deprecation")
 	public CollationProvider getCollationProvider() {
 		if (sc instanceof org.eclipse.wst.xml.xpath2.processor.DynamicContext) {
 			final org.eclipse.wst.xml.xpath2.processor.DynamicContext dc = (org.eclipse.wst.xml.xpath2.processor.DynamicContext)sc;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
@@ -44,6 +44,7 @@ public class StaticContextAdapter implements
 		org.eclipse.wst.xml.xpath2.api.StaticContext {
 	private final org.eclipse.wst.xml.xpath2.processor.StaticContext sc;
 
+	@Deprecated
 	public StaticContextAdapter(
 			org.eclipse.wst.xml.xpath2.processor.StaticContext sc) {
 		this.sc = sc;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/StaticContextAdapter.java
@@ -32,8 +32,6 @@ import org.eclipse.wst.xml.xpath2.api.StaticContext;
 import org.eclipse.wst.xml.xpath2.api.StaticVariableResolver;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
-import org.eclipse.wst.xml.xpath2.processor.DefaultDynamicContext;
-import org.eclipse.wst.xml.xpath2.processor.DynamicContext;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.NodeItemTypeImpl;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.SimpleAtomicItemTypeImpl;
@@ -84,8 +82,8 @@ public class StaticContextAdapter implements
 	}
 
 	public CollationProvider getCollationProvider() {
-		if (sc instanceof DynamicContext) {
-			final DynamicContext dc = (DynamicContext)sc;
+		if (sc instanceof org.eclipse.wst.xml.xpath2.processor.DynamicContext) {
+			final org.eclipse.wst.xml.xpath2.processor.DynamicContext dc = (org.eclipse.wst.xml.xpath2.processor.DynamicContext)sc;
 			return new CollationProvider() {
 				
 				public String getDefaultCollation() {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/XPathCup.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/XPathCup.java
@@ -9,7 +9,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
 import org.eclipse.wst.xml.xpath2.processor.internal.ast.*;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.*;
 
@@ -3251,6 +3250,7 @@ class CUP$XPathCup$actions {
   }
 
   /** Method with the actual generated action code. */
+  @SuppressWarnings("deprecation")
   public final java_cup.runtime.Symbol CUP$XPathCup$do_action(
     int                        CUP$XPathCup$act_num,
     java_cup.runtime.lr_parser CUP$XPathCup$parser,
@@ -6772,7 +6772,7 @@ class CUP$XPathCup$actions {
               Object RESULT = null;
 		int start_valleft = ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-1)).left;
 		int start_valright = ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-1)).right;
-		XPath start_val = (XPath)((java_cup.runtime.Symbol) CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-1)).value;
+		org.eclipse.wst.xml.xpath2.processor.ast.XPath start_val = (org.eclipse.wst.xml.xpath2.processor.ast.XPath)((java_cup.runtime.Symbol) CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-1)).value;
 		RESULT = start_val;
               CUP$XPathCup$result = new java_cup.runtime.Symbol(0/*$START*/, ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-1)).left, ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).right, RESULT);
             }
@@ -6783,11 +6783,11 @@ class CUP$XPathCup$actions {
           /*. . . . . . . . . . . . . . . . . . . .*/
           case 0: // XPath ::= Expr 
             {
-              XPath RESULT = null;
+              org.eclipse.wst.xml.xpath2.processor.ast.XPath RESULT = null;
 		int expsleft = ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).left;
 		int expsright = ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).right;
 		Collection exps = (Collection)((java_cup.runtime.Symbol) CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).value;
-		 RESULT = new XPath(exps); 
+		 RESULT = new org.eclipse.wst.xml.xpath2.processor.ast.XPath(exps); 
               CUP$XPathCup$result = new java_cup.runtime.Symbol(74/*XPath*/, ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).left, ((java_cup.runtime.Symbol)CUP$XPathCup$stack.elementAt(CUP$XPathCup$top-0)).right, RESULT);
             }
           return CUP$XPathCup$result;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/XPathFlex.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/XPathFlex.java
@@ -863,6 +863,7 @@ class XPathFlex implements java_cup.runtime.Scanner {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public java_cup.runtime.Symbol next_token() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/ast/XPathVisitor.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/ast/XPathVisitor.java
@@ -11,8 +11,6 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.ast;
 
-import org.eclipse.wst.xml.xpath2.processor.ast.XPath;
-
 /**
  * Visitor class for XPath expressions.
  */
@@ -20,7 +18,8 @@ public interface XPathVisitor<T> {
 	/**
 	 * Visit XPath.
 	 */
-	public T visit(XPath xp);
+	@SuppressWarnings("deprecation")
+	public T visit(org.eclipse.wst.xml.xpath2.processor.ast.XPath xp);
 
 	/**
 	 * Visit ForExpr.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/ConstructorFL.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/ConstructorFL.java
@@ -11,7 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.CtrType;
@@ -22,7 +22,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
  */
 public class ConstructorFL extends FunctionLibrary {
 
-	private Hashtable<QName, AnyAtomicType> _types;
+	private final HashMap<QName, AnyAtomicType> _types;
 
 	/**
 	 * Constructor for ConstructorFL.
@@ -33,7 +33,7 @@ public class ConstructorFL extends FunctionLibrary {
 	public ConstructorFL(String ns) {
 		super(ns);
 
-		_types = new Hashtable<QName, AnyAtomicType>();
+		_types = new HashMap<QName, AnyAtomicType>();
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
@@ -28,10 +28,9 @@ import javax.xml.datatype.DatatypeFactory;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
+import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequence;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
@@ -198,7 +197,7 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 	 *             Dynamic error.
 	 * @return Converted argument.
 	 */
-	public static org.eclipse.wst.xml.xpath2.api.ResultSequence convert_argument(org.eclipse.wst.xml.xpath2.api.ResultSequence arg,
+	public static ResultSequence convert_argument(ResultSequence arg,
 			SeqType expected) throws DynamicError {
 		ResultBuffer result = new ResultBuffer();
 
@@ -210,7 +209,7 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 			AnyAtomicType expected_aat = (AnyAtomicType) expected_type;
 			
 			// atomize
-			org.eclipse.wst.xml.xpath2.api.ResultSequence rs = FnData.atomize(arg);
+			ResultSequence rs = FnData.atomize(arg);
 
 			// cast untyped to expected type
 			for (Iterator<Item> i = rs.iterator(); i.hasNext();) {
@@ -269,13 +268,13 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 	 *             Dynamic error.
 	 * @return Converted arguments.
 	 */
-	public static Collection<org.eclipse.wst.xml.xpath2.api.ResultSequence> convert_arguments(Collection<? extends org.eclipse.wst.xml.xpath2.api.ResultSequence> args,
+	public static Collection<ResultSequence> convert_arguments(Collection<? extends ResultSequence> args,
 			Collection<? extends SeqType> expected) throws DynamicError {
-		Collection<org.eclipse.wst.xml.xpath2.api.ResultSequence> result = new ArrayList<org.eclipse.wst.xml.xpath2.api.ResultSequence>();
+		Collection<ResultSequence> result = new ArrayList<ResultSequence>();
 
 		assert args.size() <= expected.size();
 
-		Iterator<? extends org.eclipse.wst.xml.xpath2.api.ResultSequence> argi = args.iterator();
+		Iterator<? extends ResultSequence> argi = args.iterator();
 		Iterator<? extends SeqType> expi = expected.iterator();
 
 		// convert all arguments
@@ -289,7 +288,7 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 
 	protected static ResultSequence getResultSetForArityZero(EvaluationContext ec)
 			throws DynamicError {
-		ResultSequence rs = ResultSequenceFactory.create_new();
+		ResultBuffer rs = new ResultBuffer();
 		
 		Item contextItem = ec.getContextItem();
 		if (contextItem != null) {
@@ -299,7 +298,7 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 		} else {
 			throw DynamicError.contextUndefined();
 		}
-		return rs;
+		return rs.getSequence();
 	}
 
 	public boolean is_vararg() {
@@ -343,7 +342,7 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 		return BuiltinTypeLibrary.XS_UNTYPED;
 	}
 
-	public abstract org.eclipse.wst.xml.xpath2.api.ResultSequence evaluate(Collection<org.eclipse.wst.xml.xpath2.api.ResultSequence> args,
+	public abstract ResultSequence evaluate(Collection<ResultSequence> args,
 			EvaluationContext evaluationContext);
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FunctionLibrary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FunctionLibrary.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.wst.xml.xpath2.processor.DynamicContext;
@@ -38,7 +38,7 @@ public class FunctionLibrary implements org.eclipse.wst.xml.xpath2.api.FunctionL
 	 */
 	public FunctionLibrary(String ns) {
 		_namespace = ns;
-		_functions = new Hashtable<String, Function>();
+		_functions = new HashMap<String, Function>();
 		_sc = null;
 		_dc = null;
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FunctionLibrary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FunctionLibrary.java
@@ -17,8 +17,8 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.wst.xml.xpath2.processor.DynamicContext;
-import org.eclipse.wst.xml.xpath2.processor.StaticContext;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.StaticContext;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
 
 /**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
@@ -26,7 +26,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Hashtable;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
@@ -140,16 +140,16 @@ public abstract class NodeType extends AnyType {
 	}
 
 	public static org.eclipse.wst.xml.xpath2.processor.ResultSequence eliminate_dups(org.eclipse.wst.xml.xpath2.processor.ResultSequence rs) {
-		Hashtable<Node, Boolean> added = new Hashtable<Node, Boolean>(rs.size());
+		HashSet<Node> added = new HashSet<Node>(rs.size());
 
 		for (Iterator<Item> i = rs.iterator(); i.hasNext();) {
 			NodeType node = (NodeType) i.next();
 			Node n = node.node_value();
 
-			if (added.containsKey(n))
+			if (added.contains(n))
 				i.remove();
 			else
-				added.put(n, Boolean.TRUE);
+				added.add(n);
 		}
 		return rs;
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
@@ -40,7 +40,6 @@ import org.eclipse.wst.xml.xpath2.api.typesystem.SimpleTypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeModel;
 import org.eclipse.wst.xml.xpath2.processor.PsychoPathTypeHelper;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
@@ -139,7 +138,7 @@ public abstract class NodeType extends AnyType {
 		return null;
 	}
 
-	public static org.eclipse.wst.xml.xpath2.processor.ResultSequence eliminate_dups(org.eclipse.wst.xml.xpath2.processor.ResultSequence rs) {
+	public static ResultSequence eliminate_dups(ResultSequence rs) {
 		HashSet<Node> added = new HashSet<Node>(rs.size());
 
 		for (Iterator<Item> i = rs.iterator(); i.hasNext();) {
@@ -154,7 +153,7 @@ public abstract class NodeType extends AnyType {
 		return rs;
 	}
 
-	public static org.eclipse.wst.xml.xpath2.processor.ResultSequence sort_document_order(org.eclipse.wst.xml.xpath2.processor.ResultSequence rs) {
+	public static ResultSequence sort_document_order(ResultSequence rs) {
 		ArrayList<NodeType> res = new ArrayList<NodeType>(rs.size());
 
 		for (Iterator<Item> i = rs.iterator(); i.hasNext();) {
@@ -174,14 +173,14 @@ public abstract class NodeType extends AnyType {
 				res.add(node);
 		}
 
-		rs = ResultSequenceFactory.create_new();
+		ResultBuffer result = new ResultBuffer();
 		for (Iterator<NodeType> i = res.iterator(); i.hasNext();) {
 			NodeType node = i.next();
 
-			rs.add(node);
+			result.add(node);
 		}
 
-		return rs;
+		return result.getSequence();
 	}
 
 	public static boolean same(NodeType a, NodeType b) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
@@ -20,7 +20,6 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
  * 
  * @since 2.0
  */
-@SuppressWarnings("deprecation")
 public class ResultSequenceUtil {
 
 	@Deprecated

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
@@ -13,8 +13,6 @@
 
 package org.eclipse.wst.xml.xpath2.processor.util;
 
-import org.eclipse.wst.xml.xpath2.processor.ResultSequence;
-import org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 
 /**
@@ -26,12 +24,12 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 public class ResultSequenceUtil {
 
 	@Deprecated
-	public static ResultSequence newToOld(
+	public static org.eclipse.wst.xml.xpath2.processor.ResultSequence newToOld(
 			org.eclipse.wst.xml.xpath2.api.ResultSequence result) {
-		if (result instanceof ResultSequence) 
-			return (ResultSequence)result;
+		if (result instanceof org.eclipse.wst.xml.xpath2.processor.ResultSequence) 
+			return (org.eclipse.wst.xml.xpath2.processor.ResultSequence)result;
 		
-		ResultSequence rs = ResultSequenceFactory.create_new();
+		org.eclipse.wst.xml.xpath2.processor.ResultSequence rs = org.eclipse.wst.xml.xpath2.processor.ResultSequenceFactory.create_new();
 		for (int i = 0; i < result.size(); ++i) {
 			rs.add((AnyType) result.item(i));
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/ResultSequenceUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 @SuppressWarnings("deprecation")
 public class ResultSequenceUtil {
 
+	@Deprecated
 	public static ResultSequence newToOld(
 			org.eclipse.wst.xml.xpath2.api.ResultSequence result) {
 		if (result instanceof ResultSequence) 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/StaticContextBuilder.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/util/StaticContextBuilder.java
@@ -92,7 +92,7 @@ public class StaticContextBuilder implements StaticContext {
 				for (Iterator<Map.Entry<String, String>> it = _namespaces.entrySet().iterator(); it.hasNext(); ) {
 					Map.Entry<String, String> entry = it.next();					
 					if (entry.getValue().equals(ns)) {
-						return (String)entry.getKey();
+						return entry.getKey();
 					}
 				}
 				return null;


### PR DESCRIPTION
- Fix build warnings related to switch case fallthrough
- Fix build warnings related to use of deprecated types/members
- Avoid using obsolete collection classes
- Prefer new APIs over old
