### PR TITLE
Fix behavior of eq and ne comparisons for XSFloat and XSDouble values

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
@@ -266,19 +266,19 @@ public class XSDouble extends NumericType {
 		}
 		Item cat = crs.first();
 
-		/* Note: as implemented, this comparison returns false for (NaN eq NaN),
-		 * but true for (+0.0 eq -0.0). As such, it is not precisely the same
-		 * operation as either Double.equals or the == operator for double values.
-		 */
 		XSDouble d = (XSDouble) cat;
-		if (d.nan() && nan()) {
-			return false;
-		}
-		
-		Double thatvalue = d._value;
-		Double thisvalue = _value;
-		
-		return thisvalue.equals(thatvalue);
+		/* [XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition)]
+		 * op:numeric-equal($arg1 as numeric, $arg2 as numeric) as xs:boolean
+		 *
+		 *   Summary: Returns true if and only if the value of $arg1 is equal to
+		 *   the value of $arg2. For xs:float and xs:double values, positive
+		 *   zero and negative zero compare equal. INF equals INF and -INF
+		 *   equals -INF. NaN does not equal itself.
+		 */
+
+		// Operator == for double values in Java performs as described above.
+		// Note that this is NOT equivalent to the Double.equals method.
+		return _value == d._value;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
@@ -228,19 +228,19 @@ public class XSFloat extends NumericType {
 		if (!(carg instanceof XSFloat))
 			throw DynamicError.throw_type_error();
 
-		/* Note: as implemented, this comparison returns false for (NaN eq NaN),
-		 * but true for (+0.0f eq -0.0f). As such, it is not precisely the same
-		 * operation as either Float.equals or the == operator for float values.
-		 */
 		XSFloat f = (XSFloat) carg;
-		if (nan() && f.nan()) {
-			return false;
-		}
-		
-		Float thatvalue = f._value;
-		Float thisvalue = _value;
+		/* [XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition)]
+		 * op:numeric-equal($arg1 as numeric, $arg2 as numeric) as xs:boolean
+		 *
+		 *   Summary: Returns true if and only if the value of $arg1 is equal to
+		 *   the value of $arg2. For xs:float and xs:double values, positive
+		 *   zero and negative zero compare equal. INF equals INF and -INF
+		 *   equals -INF. NaN does not equal itself.
+		 */
 
-		return thisvalue.equals(thatvalue);
+		// Operator == for float values in Java performs as described above.
+		// Note that this is NOT equivalent to the Float.equals method.
+		return _value == f._value;
 	}
 
 	/**


### PR DESCRIPTION
The previous implementation of this method returned `false` for `+1.0 eq -1.0`, but should have returned `true`. This change corrects the behavior and updates the documentation to refer to the definitive source for this operation's behavior.
