### PR TITLE
Support optional collation arguments

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnContains.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnContains.java
@@ -15,8 +15,11 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -38,7 +41,7 @@ public class FnContains extends Function {
 	 * Constructor for FnContains.
 	 */
 	public FnContains() {
-		super(new QName("contains"), 2);
+		super(new QName("contains"), 2, 3);
 	}
 
 	/**
@@ -52,7 +55,7 @@ public class FnContains extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return contains(args);
+		return contains(args, ec.getDynamicContext());
 	}
 
 	/**
@@ -64,7 +67,7 @@ public class FnContains extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:contains operation.
 	 */
-	public static ResultSequence contains(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence contains(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		// get args
@@ -78,6 +81,28 @@ public class FnContains extends Function {
 		ResultSequence arg2 = argiter.next();
 		if (!arg2.empty())
 			str2 = ((XSString) arg2.first()).value();
+
+		ResultSequence arg3 = null;
+		if (argiter.hasNext()) {
+			arg3 = argiter.next();
+		}
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		String collationName;
+		if (arg3 != null) {
+			if (arg3.empty() || !(arg3.first() instanceof XSString)) {
+				throw DynamicError.argument_type_error(null);
+			}
+
+			collationName = arg3.first().getStringValue();
+		} else {
+			collationName = collationProvider.getDefaultCollation();
+		}
+
+		Comparator<String> collation = collationProvider.getCollation(collationName);
+		if (collation == null) {
+			throw DynamicError.unsupported_collation(collationName);
+		}
 
 		int str1len = str1.length();
 		int str2len = str2.length();
@@ -102,6 +127,7 @@ public class FnContains extends Function {
 		if (_expected_args == null) {
 			_expected_args = new ArrayList<SeqType>();
 			SeqType arg = new SeqType(new XSString(), SeqType.OCC_QMARK);
+			_expected_args.add(arg);
 			_expected_args.add(arg);
 			_expected_args.add(arg);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnEndsWith.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnEndsWith.java
@@ -14,8 +14,11 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -35,7 +38,7 @@ public class FnEndsWith extends Function {
 	 * Constructor for FnEndsWith.
 	 */
 	public FnEndsWith() {
-		super(new QName("ends-with"), 2);
+		super(new QName("ends-with"), 2, 3);
 	}
 
 	/**
@@ -49,7 +52,7 @@ public class FnEndsWith extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return ends_with(args);
+		return ends_with(args, ec.getDynamicContext());
 	}
 
 	/**
@@ -61,7 +64,7 @@ public class FnEndsWith extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:ends-with operation.
 	 */
-	public static ResultSequence ends_with(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence ends_with(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		// get args
@@ -76,12 +79,35 @@ public class FnEndsWith extends Function {
 		if (!arg2.empty())
 			str2 = ((XSString) arg2.first()).value();
 
+		ResultSequence arg3 = null;
+		if (argiter.hasNext()) {
+			arg3 = argiter.next();
+		}
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		String collationName;
+		if (arg3 != null) {
+			if (arg3.empty() || !(arg3.first() instanceof XSString)) {
+				throw DynamicError.argument_type_error(null);
+			}
+
+			collationName = arg3.first().getStringValue();
+		} else {
+			collationName = collationProvider.getDefaultCollation();
+		}
+
+		Comparator<String> collation = collationProvider.getCollation(collationName);
+		if (collation == null) {
+			throw DynamicError.unsupported_collation(collationName);
+		}
+
 		int str1len = str1.length();
 		int str2len = str2.length();
 
 		if (str1len == 0 && str2len != 0) {
 			return XSBoolean.FALSE;
 		}
+
 		if (str2len == 0) {
 			return XSBoolean.TRUE;
 		}
@@ -98,6 +124,7 @@ public class FnEndsWith extends Function {
 		if (_expected_args == null) {
 			_expected_args = new ArrayList<SeqType>();
 			SeqType arg = new SeqType(new XSString(), SeqType.OCC_QMARK);
+			_expected_args.add(arg);
 			_expected_args.add(arg);
 			_expected_args.add(arg);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
@@ -17,8 +17,10 @@
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
 import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
@@ -28,8 +30,10 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyAtomicType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
+import org.eclipse.wst.xml.xpath2.processor.internal.types.XSAnyURI;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSDouble;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.XSFloat;
+import org.eclipse.wst.xml.xpath2.processor.internal.types.XSString;
 import org.eclipse.wst.xml.xpath2.processor.internal.utils.ComparableTypePromoter;
 import org.eclipse.wst.xml.xpath2.processor.internal.utils.TypePromoter;
 
@@ -44,7 +48,7 @@ public class FnMax extends Function {
 	 * Constructor for FnMax.
 	 */
 	public FnMax() {
-		super(new QName("max"), 1);
+		super(new QName("max"), 1, 2);
 	}
 
 	/**
@@ -66,15 +70,15 @@ public class FnMax extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param context 
+	 * @param dynamicContext
 	 *            Relevant dynamic context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:max operation.
 	 */
 	public static ResultSequence max(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-
 		ResultSequence arg = get_arg(args, CmpGt.class);
+		Comparator<String> collation = getCollation(args, dynamicContext);
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
@@ -83,19 +87,38 @@ public class FnMax extends Function {
 		TypePromoter tp = new ComparableTypePromoter();
 		tp.considerSequence(arg);
 
+		boolean nan = false;
 		for (Iterator<Item> i = arg.iterator(); i.hasNext();) {
 			AnyAtomicType conv = tp.promote((AnyType) i.next());
 			
-			if( conv != null ){
+			if( !nan && conv != null ){
 				
 				if (conv instanceof XSDouble && ((XSDouble)conv).nan() || conv instanceof XSFloat && ((XSFloat)conv).nan()) {
-					return tp.promote(new XSFloat(Float.NaN));
+					nan = true;
 				}
-				if (max == null || ((CmpGt)conv).gt((AnyType)max, dynamicContext)) {
+
+				if (max == null) {
+					max = (CmpGt)conv;
+					continue;
+				}
+
+				boolean gt;
+				if (conv instanceof XSString || conv instanceof XSAnyURI) {
+					gt = collation.compare(conv.getStringValue(), ((AnyType)max).getStringValue()) > 0;
+				} else {
+					gt = ((CmpGt)conv).gt((AnyType)max, dynamicContext);
+				}
+
+				if (gt) {
 					max = (CmpGt)conv;
 				}
 			}
 		}
+
+		if (nan) {
+			return tp.promote(new XSFloat(Float.NaN));
+		}
+
 		return (AnyType) max;
 	}
 
@@ -112,10 +135,32 @@ public class FnMax extends Function {
 	 */
 	public static ResultSequence get_arg(Collection<ResultSequence> args, Class<?> op)
 			throws DynamicError {
-		assert args.size() == 1;
+
+		assert args.size() == 1 || args.size() == 2;
 
 		ResultSequence arg = args.iterator().next();
 
 		return arg;
+	}
+
+	public static Comparator<String> getCollation(Collection<ResultSequence> args, DynamicContext dynamicContext) {
+		assert args.size() == 1 || args.size() == 2;
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		if (args.size() == 2) {
+			Iterator<ResultSequence> iter = args.iterator();
+			iter.next();
+
+			XSString collationNamespace = (XSString)iter.next();
+			Comparator<String> collation = collationProvider.getCollation(collationNamespace.getStringValue());
+			if (collation == null) {
+				throw DynamicError.unsupported_collation(collationNamespace.getStringValue());
+			}
+
+			return collation;
+		} else {
+			Comparator<String> collation = collationProvider.getCollation(collationProvider.getDefaultCollation());
+			return collation;
+		}
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStartsWith.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStartsWith.java
@@ -14,8 +14,11 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -35,7 +38,7 @@ public class FnStartsWith extends Function {
 	 * Constructor for FnStartsWith.
 	 */
 	public FnStartsWith() {
-		super(new QName("starts-with"), 2);
+		super(new QName("starts-with"), 2, 3);
 	}
 
 	/**
@@ -49,7 +52,7 @@ public class FnStartsWith extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return starts_with(args);
+		return starts_with(args, ec.getDynamicContext());
 	}
 
 	/**
@@ -61,7 +64,7 @@ public class FnStartsWith extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:starts-with operation.
 	 */
-	public static ResultSequence starts_with(Collection<ResultSequence> args)
+	public static ResultSequence starts_with(Collection<ResultSequence> args, DynamicContext dynamicContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -76,6 +79,28 @@ public class FnStartsWith extends Function {
 		ResultSequence arg2 = argiter.next();
 		if (!arg2.empty())
 			str2 = ((XSString) arg2.first()).value();
+
+		ResultSequence arg3 = null;
+		if (argiter.hasNext()) {
+			arg3 = argiter.next();
+		}
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		String collationName;
+		if (arg3 != null) {
+			if (arg3.empty() || !(arg3.first() instanceof XSString)) {
+				throw DynamicError.argument_type_error(null);
+			}
+
+			collationName = arg3.first().getStringValue();
+		} else {
+			collationName = collationProvider.getDefaultCollation();
+		}
+
+		Comparator<String> collation = collationProvider.getCollation(collationName);
+		if (collation == null) {
+			throw DynamicError.unsupported_collation(collationName);
+		}
 
 		int str1len = str1.length();
 		int str2len = str2.length();
@@ -99,6 +124,7 @@ public class FnStartsWith extends Function {
 		if (_expected_args == null) {
 			_expected_args = new ArrayList<SeqType>();
 			SeqType arg = new SeqType(new XSString(), SeqType.OCC_QMARK);
+			_expected_args.add(arg);
 			_expected_args.add(arg);
 			_expected_args.add(arg);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringAfter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringAfter.java
@@ -16,8 +16,11 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -37,7 +40,7 @@ public class FnSubstringAfter extends Function {
 	 * Constructor for FnSubstringAfter.
 	 */
 	public FnSubstringAfter() {
-		super(new QName("substring-after"), 2);
+		super(new QName("substring-after"), 2, 3);
 	}
 
 	/**
@@ -51,7 +54,7 @@ public class FnSubstringAfter extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return substring_after(args);
+		return substring_after(args, ec.getDynamicContext());
 	}
 
 	/**
@@ -63,7 +66,7 @@ public class FnSubstringAfter extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:substring-after operation.
 	 */
-	public static ResultSequence substring_after(Collection<ResultSequence> args)
+	public static ResultSequence substring_after(Collection<ResultSequence> args, DynamicContext dynamicContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -79,6 +82,28 @@ public class FnSubstringAfter extends Function {
 		ResultSequence arg2 = argiter.next();
 		if (!arg2.empty()) {
 			str2 = ((XSString) arg2.first()).value();
+		}
+
+		ResultSequence arg3 = null;
+		if (argiter.hasNext()) {
+			arg3 = argiter.next();
+		}
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		String collationName;
+		if (arg3 != null) {
+			if (arg3.empty() || !(arg3.first() instanceof XSString)) {
+				throw DynamicError.argument_type_error(null);
+			}
+
+			collationName = arg3.first().getStringValue();
+		} else {
+			collationName = collationProvider.getDefaultCollation();
+		}
+
+		Comparator<String> collation = collationProvider.getCollation(collationName);
+		if (collation == null) {
+			throw DynamicError.unsupported_collation(collationName);
 		}
 
 		int str1len = str1.length();
@@ -112,6 +137,7 @@ public class FnSubstringAfter extends Function {
 		if (_expected_args == null) {
 			_expected_args = new ArrayList<SeqType>();
 			SeqType arg = new SeqType(new XSString(), SeqType.OCC_QMARK);
+			_expected_args.add(arg);
 			_expected_args.add(arg);
 			_expected_args.add(arg);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringBefore.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringBefore.java
@@ -16,8 +16,11 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.CollationProvider;
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -37,7 +40,7 @@ public class FnSubstringBefore extends Function {
 	 * Constructor for FnSubstringBefore.
 	 */
 	public FnSubstringBefore() {
-		super(new QName("substring-before"), 2);
+		super(new QName("substring-before"), 2, 3);
 	}
 
 	/**
@@ -51,7 +54,7 @@ public class FnSubstringBefore extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return substring_before(args);
+		return substring_before(args, ec.getDynamicContext());
 	}
 
 	/**
@@ -63,7 +66,7 @@ public class FnSubstringBefore extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:substring-before operation.
 	 */
-	public static ResultSequence substring_before(Collection<ResultSequence> args)
+	public static ResultSequence substring_before(Collection<ResultSequence> args, DynamicContext dynamicContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -79,6 +82,28 @@ public class FnSubstringBefore extends Function {
 		ResultSequence arg2 = argiter.next();
 		if (!arg2.empty()) {
 			str2 = ((XSString) arg2.first()).value();
+		}
+
+		ResultSequence arg3 = null;
+		if (argiter.hasNext()) {
+			arg3 = argiter.next();
+		}
+
+		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		String collationName;
+		if (arg3 != null) {
+			if (arg3.empty() || !(arg3.first() instanceof XSString)) {
+				throw DynamicError.argument_type_error(null);
+			}
+
+			collationName = arg3.first().getStringValue();
+		} else {
+			collationName = collationProvider.getDefaultCollation();
+		}
+
+		Comparator<String> collation = collationProvider.getCollation(collationName);
+		if (collation == null) {
+			throw DynamicError.unsupported_collation(collationName);
 		}
 
 		int str2len = str2.length();
@@ -105,6 +130,7 @@ public class FnSubstringBefore extends Function {
 		if (_expected_args == null) {
 			_expected_args = new ArrayList<SeqType>();
 			SeqType arg = new SeqType(new XSString(), SeqType.OCC_QMARK);
+			_expected_args.add(arg);
 			_expected_args.add(arg);
 			_expected_args.add(arg);
 		}


### PR DESCRIPTION
> :memo: No additional collations are currently defined, but the tests pass because no additional collations are actually required.

Fixes #31 
Fixes #32 
Fixes #52 
Fixes #53 
Fixes #54 
Fixes #55 
Fixes #56
