### PR TITLE
Pass EvaluationContext instead of DynamicContext to many internal methods

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -649,40 +649,40 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 
 		switch (cmpex.type()) {
 		case CmpExpr.EQ:
-			return FsEq.fs_eq_value(args, _dc);
+			return FsEq.fs_eq_value(args, _ec);
 
 		case CmpExpr.NE:
-			return FsNe.fs_ne_value(args, _dc);
+			return FsNe.fs_ne_value(args, _ec);
 
 		case CmpExpr.GT:
-			return FsGt.fs_gt_value(args, _dc);
+			return FsGt.fs_gt_value(args, _ec);
 
 		case CmpExpr.LT:
-			return FsLt.fs_lt_value(args, _dc);
+			return FsLt.fs_lt_value(args, _ec);
 
 		case CmpExpr.GE:
-			return FsGe.fs_ge_value(args, _dc);
+			return FsGe.fs_ge_value(args, _ec);
 
 		case CmpExpr.LE:
-			return FsLe.fs_le_value(args, _dc);
+			return FsLe.fs_le_value(args, _ec);
 
 		case CmpExpr.EQUALS:
-			return FsEq.fs_eq_general(args, _dc);
+			return FsEq.fs_eq_general(args, _ec);
 
 		case CmpExpr.NOTEQUALS:
-			return FsNe.fs_ne_general(args, _dc);
+			return FsNe.fs_ne_general(args, _ec);
 
 		case CmpExpr.GREATER:
-			return FsGt.fs_gt_general(args, _dc);
+			return FsGt.fs_gt_general(args, _ec);
 
 		case CmpExpr.LESSTHAN:
-			return FsLt.fs_lt_general(args, _dc);
+			return FsLt.fs_lt_general(args, _ec);
 
 		case CmpExpr.GREATEREQUAL:
-			return FsGe.fs_ge_general(args, _dc);
+			return FsGe.fs_ge_general(args, _ec);
 
 		case CmpExpr.LESSEQUAL:
-			return FsLe.fs_le_general(args, _dc);
+			return FsLe.fs_le_general(args, _ec);
 
 		case CmpExpr.IS:
 		case CmpExpr.LESS_LESS:
@@ -729,7 +729,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(AddExpr addex) {
 		Collection<ResultSequence> args = do_bin_args(addex);
-		return FsPlus.fs_plus(args);
+		return FsPlus.fs_plus(args, _ec);
 	}
 
 	/**
@@ -742,7 +742,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(SubExpr subex) {
 		Collection<ResultSequence> args = do_bin_args(subex);
-		return FsMinus.fs_minus(args);
+		return FsMinus.fs_minus(args, _ec);
 	}
 
 	/**
@@ -755,7 +755,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(MulExpr mulex) {
 		Collection<ResultSequence> args = do_bin_args(mulex);
-		return FsTimes.fs_times(args);
+		return FsTimes.fs_times(args, _ec);
 	}
 
 	/**
@@ -768,7 +768,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(DivExpr mulex) {
 		Collection<ResultSequence> args = do_bin_args(mulex);
-		return FsDiv.fs_div(args);
+		return FsDiv.fs_div(args, _ec);
 	}
 
 	/**
@@ -781,7 +781,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(IDivExpr mulex) {
 		Collection<ResultSequence> args = do_bin_args(mulex);
-		return FsIDiv.fs_idiv(args);
+		return FsIDiv.fs_idiv(args, _ec);
 	}
 
 	/**
@@ -794,7 +794,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	@Override
 	public ResultSequence visit(ModExpr mulex) {
 		Collection<ResultSequence> args = do_bin_args(mulex);
-		return FsMod.fs_mod(args);
+		return FsMod.fs_mod(args, _ec);
 	}
 
 	private Collection<ResultSequence> do_bin_args(BinExpr e) {
@@ -1937,7 +1937,7 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 			AnyType at = (AnyType) rs.item(0);
 
 			if (at instanceof NumericType) {
-				return FsEq.fs_eq_fast(at, new XSInteger(BigInteger.valueOf(focus().position())), _dc);
+				return FsEq.fs_eq_fast(at, new XSInteger(BigInteger.valueOf(focus().position())), _ec);
 			}
 		}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/DefaultEvaluator.java
@@ -299,8 +299,6 @@ public class DefaultEvaluator implements XPathVisitor<ResultSequence>, Evaluator
 	 * 
 	 * @param node
 	 *            is the xpath node.
-	 * @throws dynamic
-	 *             error.
 	 * @return result sequence.
 	 */
 	@Deprecated

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractCollationEqualFunction.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractCollationEqualFunction.java
@@ -14,7 +14,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 import java.math.BigInteger;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -43,25 +43,25 @@ public abstract class AbstractCollationEqualFunction extends Function {
 	}
 
 
-	protected static boolean hasValue(AnyType itema, AnyType itemb, DynamicContext context, String collationURI) throws DynamicError {
+	protected static boolean hasValue(AnyType itema, AnyType itemb, EvaluationContext evaluationContext, String collationURI) throws DynamicError {
 		XSString itemStr = new XSString(itema.getStringValue());
 		if (isBoolean(itema, itemb)) {
 			XSBoolean boolat = (XSBoolean) itema;
-			if (boolat.eq(itemb, context)) {
+			if (boolat.eq(itemb, evaluationContext)) {
 				return true;
 			}
 		}
 
 		if (isNumeric(itema, itemb)) {
 			NumericType numericat = (NumericType) itema;
-			if (numericat.eq(itemb, context)) {
+			if (numericat.eq(itemb, evaluationContext)) {
 				return true;
 			}
 		}
 
 		if (isDuration(itema, itemb)) {
 			XSDuration durat = (XSDuration) itema;
-			if (durat.eq(itemb, context)) {
+			if (durat.eq(itemb, evaluationContext)) {
 				return true;
 			}
 		}
@@ -69,7 +69,7 @@ public abstract class AbstractCollationEqualFunction extends Function {
 		if (needsStringComparison(itema, itemb)) {
 			XSString xstr1 = new XSString(itema.getStringValue());
 			if (FnCompare.compare_string(collationURI, xstr1, itemStr,
-					context).equals(BigInteger.ZERO)) {
+					evaluationContext).equals(BigInteger.ZERO)) {
 				return true;
 			}
 		}
@@ -77,7 +77,7 @@ public abstract class AbstractCollationEqualFunction extends Function {
 	}
 	
 	protected static boolean hasValue(ResultBuffer rs, AnyAtomicType item,
-			DynamicContext context, String collationURI) throws DynamicError {
+			EvaluationContext evaluationContext, String collationURI) throws DynamicError {
 		XSString itemStr = new XSString(item.getStringValue());
 
 		for (Iterator<Item> i = rs.iterator(); i.hasNext();) {
@@ -88,21 +88,21 @@ public abstract class AbstractCollationEqualFunction extends Function {
 
 			if (isBoolean(item, at)) {
 				XSBoolean boolat = (XSBoolean) at;
-				if (boolat.eq(item, context)) {
+				if (boolat.eq(item, evaluationContext)) {
 					return true;
 				}
 			}
 
 			if (isNumeric(item, at)) {
 				NumericType numericat = (NumericType) at;
-				if (numericat.eq(item, context)) {
+				if (numericat.eq(item, evaluationContext)) {
 					return true;
 				}
 			}
 
 			if (isDuration(item, at)) {
 				XSDuration durat = (XSDuration) at;
-				if (durat.eq(item, context)) {
+				if (durat.eq(item, evaluationContext)) {
 					return true;
 				}
 			}
@@ -110,7 +110,7 @@ public abstract class AbstractCollationEqualFunction extends Function {
 			if (needsStringComparison(item, at)) {
 				XSString xstr1 = new XSString(at.getStringValue());
 				if (FnCompare.compare_string(collationURI, xstr1, itemStr,
-						context).equals(BigInteger.ZERO)) {
+						evaluationContext).equals(BigInteger.ZERO)) {
 					return true;
 				}
 			}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpEq.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpEq.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 
@@ -30,5 +30,5 @@ public interface CmpEq {
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.
 	 */
-	public boolean eq(AnyType arg, DynamicContext context) throws DynamicError;
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpEq.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpEq.java
@@ -25,7 +25,7 @@ public interface CmpEq {
 	 * 
 	 * @param arg
 	 *            argument of any type.
-	 * @param context TODO
+	 * @param evaluationContext current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpGt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpGt.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 
@@ -30,5 +30,5 @@ public interface CmpGt {
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.
 	 */
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError;
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpGt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpGt.java
@@ -25,7 +25,7 @@ public interface CmpGt {
 	 * 
 	 * @param arg
 	 *            argument of any type.
-	 * @param context TODO
+	 * @param evaluationContext current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpLt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpLt.java
@@ -25,7 +25,7 @@ public interface CmpLt {
 	 * 
 	 * @param arg
 	 *            argument of any type.
-	 * @param context TODO
+	 * @param evaluationContext Current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpLt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/CmpLt.java
@@ -12,7 +12,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType;
 
@@ -30,5 +30,5 @@ public interface CmpLt {
 	 *             Dynamic error.
 	 * @return Result of operation, true/false.
 	 */
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError;
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateTimeToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateTimeToTimeZone.java
@@ -61,7 +61,7 @@ public class FnAdjustDateTimeToTimeZone extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return adjustdateTime(args, ec.getDynamicContext());
+		return adjustdateTime(args, ec);
 	}
 
 	/**
@@ -75,9 +75,7 @@ public class FnAdjustDateTimeToTimeZone extends Function {
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.
 	 */
-	public static ResultSequence adjustdateTime(Collection<ResultSequence> args,
-			org.eclipse.wst.xml.xpath2.api.DynamicContext dynamicContext) throws DynamicError {
-
+	public static ResultSequence adjustdateTime(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expectedArgs());
 
 		// get args
@@ -106,7 +104,7 @@ public class FnAdjustDateTimeToTimeZone extends Function {
 		}
 
 		timezone = (XSDayTimeDuration) arg2.item(0);
-		if (timezone.lt(minDuration, dynamicContext) || timezone.gt(maxDuration, dynamicContext)) {
+		if (timezone.lt(minDuration, evaluationContext) || timezone.gt(maxDuration, evaluationContext)) {
 			throw DynamicError.invalidTimezone();
 		}
 		

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateTimeToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateTimeToTimeZone.java
@@ -69,8 +69,8 @@ public class FnAdjustDateTimeToTimeZone extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param sc
-	 *            Result of static context operation.
+	 * @param evaluationContext
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateToTimeZone.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -61,7 +60,7 @@ public class FnAdjustDateToTimeZone extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return adjustDate(args, ec.getDynamicContext());
+		return adjustDate(args, ec);
 	}
 
 	/**
@@ -75,9 +74,7 @@ public class FnAdjustDateToTimeZone extends Function {
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.
 	 */
-	public static ResultSequence adjustDate(Collection<ResultSequence> args,
-			DynamicContext dc) throws DynamicError {
-
+	public static ResultSequence adjustDate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expectedArgs());
 
 		// get args
@@ -103,7 +100,7 @@ public class FnAdjustDateToTimeZone extends Function {
 		}
 		
 		timezone = (XSDayTimeDuration) arg2.item(0);
-		if (timezone.lt(minDuration, dc) || timezone.gt(maxDuration, dc)) {
+		if (timezone.lt(minDuration, evaluationContext) || timezone.gt(maxDuration, evaluationContext)) {
 			throw DynamicError.invalidTimezone();
 		}
 		

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustDateToTimeZone.java
@@ -68,8 +68,8 @@ public class FnAdjustDateToTimeZone extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param sc
-	 *            Result of static context operation.
+	 * @param evaluationContext
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustTimeToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustTimeToTimeZone.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -62,7 +61,7 @@ public class FnAdjustTimeToTimeZone extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return adjustTime(args, ec.getDynamicContext());
+		return adjustTime(args, ec);
 	}
 
 	/**
@@ -76,9 +75,7 @@ public class FnAdjustTimeToTimeZone extends Function {
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.
 	 */
-	public static ResultSequence adjustTime(Collection<ResultSequence> args,
-			DynamicContext dc) throws DynamicError {
-
+	public static ResultSequence adjustTime(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expectedArgs());
 
 		// get args
@@ -113,7 +110,7 @@ public class FnAdjustTimeToTimeZone extends Function {
 		}
 
 		timezone = (XSDayTimeDuration) arg2.first();
-		if (timezone.lt(minDuration, dc) || timezone.gt(maxDuration, dc)) {
+		if (timezone.lt(minDuration, evaluationContext) || timezone.gt(maxDuration, evaluationContext)) {
 			throw DynamicError.invalidTimezone();
 		}
 		

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustTimeToTimeZone.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAdjustTimeToTimeZone.java
@@ -69,8 +69,8 @@ public class FnAdjustTimeToTimeZone extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param sc
-	 *            Result of static context operation.
+	 * @param evaluationContext
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the fn:dateTime operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnAvg.java
@@ -60,8 +60,8 @@ public class FnAvg extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return avg(args);
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+		return avg(args, evaluationContext);
 	}
 
 	/**
@@ -73,7 +73,7 @@ public class FnAvg extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:avg operation.
 	 */
-	public static ResultSequence avg(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence avg(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 
 		ResultSequence arg = args.iterator().next();
 
@@ -98,7 +98,7 @@ public class FnAvg extends Function {
 				if (total == null) {
 					total = (MathPlus)conv; 
 				} else {
-					total = (MathPlus)total.plus(conv).first();
+					total = (MathPlus)total.plus(conv, evaluationContext).first();
 				}
 			}
 		}
@@ -106,7 +106,7 @@ public class FnAvg extends Function {
 		if (!(total instanceof MathDiv))
 			throw DynamicError.throw_type_error();
 
-		return ((MathDiv)total).div(new XSInteger(BigInteger.valueOf(elems)));
+		return ((MathDiv)total).div(new XSInteger(BigInteger.valueOf(elems)), evaluationContext);
 	}
 	
 	@Override

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnBaseUri.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnBaseUri.java
@@ -70,8 +70,8 @@ public class FnBaseUri extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param d_context
-	 * 			  Dynamic context
+	 * @param ec
+	 * 			  Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:base-uri operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCodepointEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCodepointEqual.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -72,7 +71,7 @@ public class FnCodepointEqual extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return codepoint_equals(args, ec.getDynamicContext());
+		return codepoint_equals(args, ec);
 	}
 
 	/**
@@ -80,13 +79,13 @@ public class FnCodepointEqual extends Function {
 	 * 
 	 * @param args
 	 *            are compared.
-	 * @param dynamicContext
-	 *            The current dynamic context
+	 * @param evaluationContext
+	 *            The current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return The result of the comparison of the arguments.
 	 */
-	public static ResultSequence codepoint_equals(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
+	public static ResultSequence codepoint_equals(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		ResultBuffer rs = new ResultBuffer();
@@ -99,7 +98,7 @@ public class FnCodepointEqual extends Function {
 		XSString xstr2 = arg2.empty() ? null : (XSString) arg2.first();
 
 		// This delegates to FnCompare
-		BigInteger result = FnCompare.compare_string(CollationProvider.CODEPOINT_COLLATION, xstr1, xstr2, dynamicContext);
+		BigInteger result = FnCompare.compare_string(CollationProvider.CODEPOINT_COLLATION, xstr1, xstr2, evaluationContext);
 		if (result != null) rs.add(XSBoolean.valueOf(BigInteger.ZERO.equals(result)));
 		
 		return rs.getSequence();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCollection.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCollection.java
@@ -91,8 +91,8 @@ public class FnCollection extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:doc operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -81,7 +80,7 @@ public class FnCompare extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return compare(args, ec.getDynamicContext());
+		return compare(args, ec);
 	}
 
 	/**
@@ -95,14 +94,14 @@ public class FnCompare extends Function {
 	 *             Dynamic error.
 	 * @return The result of the comparison of the arguments.
 	 */
-	public static ResultSequence compare(Collection<ResultSequence> args, DynamicContext context) throws DynamicError {
+	public static ResultSequence compare(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		Iterator<ResultSequence> argiter = cargs.iterator();
 		ResultSequence arg1 = argiter.next();
 		ResultSequence arg2 = argiter.next();
 
-		String collationUri = context.getCollationProvider().getDefaultCollation();
+		String collationUri = evaluationContext.getDynamicContext().getCollationProvider().getDefaultCollation();
 		if (argiter.hasNext()) {
 			ResultSequence collArg = argiter.next();
 			collationUri = collArg.first().getStringValue();
@@ -111,7 +110,7 @@ public class FnCompare extends Function {
 		XSString xstr1 = arg1.empty() ? null : (XSString) arg1.first();
 		XSString xstr2 = arg2.empty() ? null : (XSString) arg2.first();
 
-		BigInteger result = compare_string(collationUri, xstr1, xstr2, context);
+		BigInteger result = compare_string(collationUri, xstr1, xstr2, evaluationContext);
 		if (result != null) {
 			return new XSInteger(result);
 		} else {
@@ -120,8 +119,8 @@ public class FnCompare extends Function {
 	}
 
 	public static BigInteger compare_string(String collationUri, XSString xstr1,
-			XSString xstr2, DynamicContext context) throws DynamicError {
-		Comparator<String> collator = context.getCollationProvider().getCollation(collationUri);
+			XSString xstr2, EvaluationContext evaluationContext) throws DynamicError {
+		Comparator<String> collator = evaluationContext.getDynamicContext().getCollationProvider().getCollation(collationUri);
 		if (collator == null) throw DynamicError.unsupported_collation(collationUri);
 
 		if (xstr1 == null || xstr2 == null) return null;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnCompare.java
@@ -88,8 +88,8 @@ public class FnCompare extends Function {
 	 * 
 	 * @param args
 	 *            are compared (optional 3rd argument is the collation)
-	 * @param dynamicContext
-	 * 	       Current dynamic context 
+	 * @param evaluationContext
+	 * 	       Current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return The result of the comparison of the arguments.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnContains.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnContains.java
@@ -55,7 +55,7 @@ public class FnContains extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return contains(args, ec.getDynamicContext());
+		return contains(args, ec);
 	}
 
 	/**
@@ -67,7 +67,7 @@ public class FnContains extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:contains operation.
 	 */
-	public static ResultSequence contains(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
+	public static ResultSequence contains(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		// get args
@@ -87,7 +87,7 @@ public class FnContains extends Function {
 			arg3 = argiter.next();
 		}
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		String collationName;
 		if (arg3 != null) {
 			if (arg3.empty() || !(arg3.first() instanceof XSString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
@@ -17,7 +17,6 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -74,7 +73,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 	 *             Dynamic error.
 	 * @return Result of fn:deep-equal operation.
 	 */
-	public static ResultSequence deep_equal(Collection<ResultSequence> args, EvaluationContext context)
+	public static ResultSequence deep_equal(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 
 		// get args
@@ -82,7 +81,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 		ResultSequence arg1 = citer.next();
 		ResultSequence arg2 = citer.next();
 		ResultSequence arg3 = null;
-		String collationURI = context.getStaticContext().getCollationProvider().getDefaultCollation();
+		String collationURI = evaluationContext.getStaticContext().getCollationProvider().getDefaultCollation();
 		if (citer.hasNext()) {
 			arg3 = citer.next();
 			if (!arg3.empty()) {
@@ -90,7 +89,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 			}
 		}
 
-		boolean result = deep_equal(arg1, arg2, context, collationURI);
+		boolean result = deep_equal(arg1, arg2, evaluationContext, collationURI);
 
 		return XSBoolean.valueOf(result);
 	}
@@ -138,7 +137,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 	 */
 	public static boolean deep_equal(AnyType one, AnyType two, EvaluationContext context, String collationURI) {
 		if ((one instanceof AnyAtomicType) && (two instanceof AnyAtomicType))
-			return deep_equal_atomic((AnyAtomicType) one, (AnyAtomicType) two, context.getDynamicContext(), collationURI);
+			return deep_equal_atomic((AnyAtomicType) one, (AnyAtomicType) two, context, collationURI);
 
 		else if (((one instanceof AnyAtomicType) && (two instanceof NodeType))
 				|| ((one instanceof NodeType) && (two instanceof AnyAtomicType)))
@@ -159,7 +158,7 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 	 *            input2 xpath expression/variable.
 	 * @return Result of fn:deep-equal operation.
 	 */
-	public static boolean deep_equal_atomic(AnyAtomicType one, AnyAtomicType two, DynamicContext context, String collationURI) {
+	public static boolean deep_equal_atomic(AnyAtomicType one, AnyAtomicType two, EvaluationContext evaluationContext, String collationURI) {
 		if (!(one instanceof CmpEq))
 			return false;
 		if (!(two instanceof CmpEq))
@@ -170,24 +169,23 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 		try {
 			if (isNumeric(one, two)) {
 				NumericType numeric = (NumericType) one;
-				if (numeric.eq(two, context)) {
+				if (numeric.eq(two, evaluationContext)) {
 					return true;
 				} else {
 					XSString value1 = new XSString(one.getStringValue());
-					if (value1.eq(two, context)) {
+					if (value1.eq(two, evaluationContext)) {
 						return true;
 					}
 				}
 			}
 
-			if (a.eq(two, context))
+			if (a.eq(two, evaluationContext))
 				return true;
 			
 			if (needsStringComparison(one, two)) {
 				XSString xstr1 = new XSString(one.getStringValue());
 				XSString xstr2 = new XSString(two.getStringValue());
-				if (FnCompare.compare_string(collationURI, xstr1, xstr2,
-						context).equals(BigInteger.ZERO)) {
+				if (FnCompare.compare_string(collationURI, xstr1, xstr2, evaluationContext).equals(BigInteger.ZERO)) {
 					return true;
 				}
 			}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDeepEqual.java
@@ -67,8 +67,8 @@ public class FnDeepEqual extends AbstractCollationEqualFunction {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param context
-	 *            Dynamic context
+	 * @param evaluationContext
+	 *            Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:deep-equal operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDistinctValues.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDistinctValues.java
@@ -23,7 +23,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
@@ -60,7 +59,7 @@ public class FnDistinctValues extends AbstractCollationEqualFunction {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return distinct_values(args, ec.getDynamicContext());
+		return distinct_values(args, ec);
 	}
 
 	/**
@@ -72,7 +71,7 @@ public class FnDistinctValues extends AbstractCollationEqualFunction {
 	 *             Dynamic error.
 	 * @return Result of fn:distinct-values operation.
 	 */
-	public static ResultSequence distinct_values(Collection<ResultSequence> args, DynamicContext context) throws DynamicError {
+	public static ResultSequence distinct_values(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 
 		ResultBuffer rs = new ResultBuffer();
 
@@ -84,7 +83,7 @@ public class FnDistinctValues extends AbstractCollationEqualFunction {
 			arg2 = citer.next();
 		}
 		
-		String collationURI = context.getCollationProvider().getDefaultCollation();
+		String collationURI = evaluationContext.getDynamicContext().getCollationProvider().getDefaultCollation();
 		if (!arg2.empty()) {
 			XSString collation = (XSString) arg2.item(0);
 			collationURI = collation.getStringValue();
@@ -92,7 +91,7 @@ public class FnDistinctValues extends AbstractCollationEqualFunction {
 
 		for (Iterator<Item> iter = arg1.iterator(); iter.hasNext();) {
 			AnyAtomicType atomizedItem = (AnyAtomicType) FnData.atomize(iter.next());
-			if (!contains(rs, atomizedItem, context, collationURI))
+			if (!contains(rs, atomizedItem, evaluationContext, collationURI))
 				rs.add(atomizedItem);
 		}
 
@@ -110,12 +109,11 @@ public class FnDistinctValues extends AbstractCollationEqualFunction {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	protected static boolean contains(ResultBuffer rs, AnyAtomicType item,
-			DynamicContext context, String collationURI)  {
+	protected static boolean contains(ResultBuffer rs, AnyAtomicType item, EvaluationContext evaluationContext, String collationURI) {
 		if (!(item instanceof CmpEq))
 			return false;
 
-		return hasValue(rs, item, context, collationURI);
+		return hasValue(rs, item, evaluationContext, collationURI);
 	}
 	
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDoc.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDoc.java
@@ -70,8 +70,8 @@ public class FnDoc extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:doc operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDocAvailable.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnDocAvailable.java
@@ -79,7 +79,7 @@ public class FnDocAvailable extends Function {
 	 * this guarantee is lost.</p>
 	 *
 	 * @param args Result from the expressions evaluation.
-	 * @param dc Result of dynamic context operation.
+	 * @param evaluationContext Current evaluation context.
 	 * @throws DynamicError Dynamic error.
 	 * @return Result of fn:doc-available operation.
 	 */

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnEndsWith.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnEndsWith.java
@@ -18,7 +18,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -51,8 +51,8 @@ public class FnEndsWith extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return ends_with(args, ec.getDynamicContext());
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+		return ends_with(args, ec);
 	}
 
 	/**
@@ -64,7 +64,7 @@ public class FnEndsWith extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:ends-with operation.
 	 */
-	public static ResultSequence ends_with(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
+	public static ResultSequence ends_with(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
 		// get args
@@ -84,7 +84,7 @@ public class FnEndsWith extends Function {
 			arg3 = argiter.next();
 		}
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		String collationName;
 		if (arg3 != null) {
 			if (arg3.empty() || !(arg3.first() instanceof XSString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnError.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnError.java
@@ -91,8 +91,6 @@ public class FnError extends Function {
 	/**
 	 * Error operation.
 	 * 
-	 * @param args
-	 *            Result from the expressions evaluation.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:error operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnIDREF.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnIDREF.java
@@ -69,7 +69,7 @@ public class FnIDREF extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc 
+	 * @param ec current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:insert-before operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnIndexOf.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnIndexOf.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
@@ -62,7 +61,7 @@ public class FnIndexOf extends AbstractCollationEqualFunction {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return index_of(args, ec.getDynamicContext());
+		return index_of(args, ec);
 	}
 
 	/**
@@ -94,12 +93,12 @@ public class FnIndexOf extends AbstractCollationEqualFunction {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dynamicContext 
+	 * @param evaluationContext
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:index-of operation.
 	 */
-	public static ResultSequence index_of(Collection<ResultSequence> args, DynamicContext dc) {
+	public static ResultSequence index_of(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		Function.convert_arguments(args, expected_args());
 
 		// get args
@@ -115,7 +114,7 @@ public class FnIndexOf extends AbstractCollationEqualFunction {
 		if (arg2.size() != 1)
 			throw DynamicError.throw_type_error();
 		
-		String collationUri = dc.getCollationProvider().getDefaultCollation();
+		String collationUri = evaluationContext.getDynamicContext().getCollationProvider().getDefaultCollation();
 		if (citer.hasNext()) {
 			ResultSequence arg3 = citer.next();
 			if (!arg3.empty()) {
@@ -140,28 +139,28 @@ public class FnIndexOf extends AbstractCollationEqualFunction {
 			
 			if (isBoolean(cmptype, at)) {
 				XSBoolean boolat = (XSBoolean) cmptype;
-				if (boolat.eq(at, dc)) {
+				if (boolat.eq(at, evaluationContext)) {
  				   rb.add(new XSInteger(BigInteger.valueOf(index)));
 				}
 			} else 
 			
 			if (isNumeric(cmptype, at)) {
 				NumericType numericat = (NumericType) at;
-				if (numericat.eq(cmptype, dc)) {
+				if (numericat.eq(cmptype, evaluationContext)) {
 					rb.add(new XSInteger(BigInteger.valueOf(index)));
 				}
 			} else
 			
 			if (isDuration(cmptype, at)) {
 				XSDuration durat = (XSDuration) at;
-				if (durat.eq(cmptype, dc)) {
+				if (durat.eq(cmptype, evaluationContext)) {
 					rb.add(new XSInteger(BigInteger.valueOf(index)));
 				}
 			} else
 				
 			if (at instanceof QName && cmptype instanceof QName ) {
 				QName qname = (QName)at;
-				if (qname.eq(cmptype, dc)) {
+				if (qname.eq(cmptype, evaluationContext)) {
 					rb.add(new XSInteger(BigInteger.valueOf(index)));
 				}
 			} else 
@@ -169,7 +168,7 @@ public class FnIndexOf extends AbstractCollationEqualFunction {
 			if (needsStringComparison(cmptype, at)) {
 				XSString xstr1 = new XSString(cmptype.getStringValue());
 				XSString itemStr = new XSString(at.getStringValue());
-				if (FnCompare.compare_string(collationUri, xstr1, itemStr, dc).equals(BigInteger.ZERO)) {
+				if (FnCompare.compare_string(collationUri, xstr1, itemStr, evaluationContext).equals(BigInteger.ZERO)) {
 					rb.add(new XSInteger(BigInteger.valueOf(index)));
 				}
 			} 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLast.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnLast.java
@@ -53,8 +53,8 @@ public class FnLast extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:last operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMax.java
@@ -21,7 +21,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
@@ -62,7 +61,7 @@ public class FnMax extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
-		return max(args, ec.getDynamicContext());
+		return max(args, ec);
 	}
 
 	/**
@@ -70,15 +69,15 @@ public class FnMax extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dynamicContext
-	 *            Relevant dynamic context
+	 * @param evaluationContext
+	 *            Relevant evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:max operation.
 	 */
-	public static ResultSequence max(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
+	public static ResultSequence max(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence arg = get_arg(args, CmpGt.class);
-		Comparator<String> collation = getCollation(args, dynamicContext);
+		Comparator<String> collation = getCollation(args, evaluationContext);
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
@@ -106,7 +105,7 @@ public class FnMax extends Function {
 				if (conv instanceof XSString || conv instanceof XSAnyURI) {
 					gt = collation.compare(conv.getStringValue(), ((AnyType)max).getStringValue()) > 0;
 				} else {
-					gt = ((CmpGt)conv).gt((AnyType)max, dynamicContext);
+					gt = ((CmpGt)conv).gt((AnyType)max, evaluationContext);
 				}
 
 				if (gt) {
@@ -143,10 +142,10 @@ public class FnMax extends Function {
 		return arg;
 	}
 
-	public static Comparator<String> getCollation(Collection<ResultSequence> args, DynamicContext dynamicContext) {
+	public static Comparator<String> getCollation(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		assert args.size() == 1 || args.size() == 2;
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		if (args.size() == 2) {
 			Iterator<ResultSequence> iter = args.iterator();
 			iter.next();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMin.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
@@ -61,7 +60,7 @@ public class FnMin extends Function {
 	 */
 	@Override
 	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
-		return min(args, ec.getDynamicContext());
+		return min(args, ec);
 	}
 
 	/**
@@ -69,15 +68,15 @@ public class FnMin extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param context
-	 *            Dynamic context
+	 * @param evaluationContext
+	 *            Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:min operation.
 	 */
-	public static ResultSequence min(Collection<ResultSequence> args, DynamicContext context) throws DynamicError {
+	public static ResultSequence min(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence arg = FnMax.get_arg(args, CmpLt.class);
-		Comparator<String> collation = FnMax.getCollation(args, context);
+		Comparator<String> collation = FnMax.getCollation(args, evaluationContext);
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
@@ -105,7 +104,7 @@ public class FnMin extends Function {
 				if (conv instanceof XSString || conv instanceof XSAnyURI) {
 					lt = collation.compare(conv.getStringValue(), ((AnyType)max).getStringValue()) < 0;
 				} else {
-					lt = ((CmpLt)conv).lt((AnyType)max, context);
+					lt = ((CmpLt)conv).lt((AnyType)max, evaluationContext);
 				}
 
 				if (lt) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnName.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnName.java
@@ -61,8 +61,8 @@ public class FnName extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param context
-	 *            Dynamic context.
+	 * @param ec
+	 *            Evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:name operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNumber.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnNumber.java
@@ -73,8 +73,8 @@ public class FnNumber extends Function {
 	 * 
 	 * @param arg
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:number operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnPosition.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnPosition.java
@@ -54,8 +54,8 @@ public class FnPosition extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:position operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnResolveURI.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnResolveURI.java
@@ -71,8 +71,8 @@ public class FnResolveURI extends Function {
 	 * 
 	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param d_context
-	 *            Dynamic context
+	 * @param ec
+	 *            Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:resolve-uri operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnRoot.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnRoot.java
@@ -68,10 +68,10 @@ public class FnRoot extends Function {
 	/**
 	 * Root operation.
 	 * 
-	 * @param arg
+	 * @param args
 	 *            Result from the expressions evaluation.
-	 * @param dc
-	 *            Result of dynamic context operation.
+	 * @param ec
+	 *            Current evaluation context.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of fn:root operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStartsWith.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnStartsWith.java
@@ -18,7 +18,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -51,8 +51,8 @@ public class FnStartsWith extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return starts_with(args, ec.getDynamicContext());
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+		return starts_with(args, ec);
 	}
 
 	/**
@@ -64,7 +64,7 @@ public class FnStartsWith extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:starts-with operation.
 	 */
-	public static ResultSequence starts_with(Collection<ResultSequence> args, DynamicContext dynamicContext)
+	public static ResultSequence starts_with(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -85,7 +85,7 @@ public class FnStartsWith extends Function {
 			arg3 = argiter.next();
 		}
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		String collationName;
 		if (arg3 != null) {
 			if (arg3.empty() || !(arg3.first() instanceof XSString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringAfter.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringAfter.java
@@ -20,7 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -53,8 +53,8 @@ public class FnSubstringAfter extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return substring_after(args, ec.getDynamicContext());
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+		return substring_after(args, ec);
 	}
 
 	/**
@@ -66,7 +66,7 @@ public class FnSubstringAfter extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:substring-after operation.
 	 */
-	public static ResultSequence substring_after(Collection<ResultSequence> args, DynamicContext dynamicContext)
+	public static ResultSequence substring_after(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -89,7 +89,7 @@ public class FnSubstringAfter extends Function {
 			arg3 = argiter.next();
 		}
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		String collationName;
 		if (arg3 != null) {
 			if (arg3.empty() || !(arg3.first() instanceof XSString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringBefore.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSubstringBefore.java
@@ -20,7 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 
 import org.eclipse.wst.xml.xpath2.api.CollationProvider;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.SeqType;
@@ -53,8 +53,8 @@ public class FnSubstringBefore extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
-		return substring_before(args, ec.getDynamicContext());
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+		return substring_before(args, ec);
 	}
 
 	/**
@@ -66,7 +66,7 @@ public class FnSubstringBefore extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:substring-before operation.
 	 */
-	public static ResultSequence substring_before(Collection<ResultSequence> args, DynamicContext dynamicContext)
+	public static ResultSequence substring_before(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		Collection<ResultSequence> cargs = Function.convert_arguments(args, expected_args());
 
@@ -89,7 +89,7 @@ public class FnSubstringBefore extends Function {
 			arg3 = argiter.next();
 		}
 
-		CollationProvider collationProvider = dynamicContext.getCollationProvider();
+		CollationProvider collationProvider = evaluationContext.getDynamicContext().getCollationProvider();
 		String collationName;
 		if (arg3 != null) {
 			if (arg3.empty() || !(arg3.first() instanceof XSString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -60,7 +61,7 @@ public class FnSum extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		Iterator<ResultSequence> argIterator = args.iterator();
 		ResultSequence argSequence = argIterator.next();
 		AnyAtomicType zero = ZERO;
@@ -72,7 +73,7 @@ public class FnSum extends Function {
 				throw new DynamicError(TypeError.invalid_type(zeroSequence.first().getStringValue()));
 			zero = (AnyAtomicType)zeroSequence.first();
 		}
-		return sum(argSequence, zero);
+		return sum(argSequence, zero, evaluationContext);
 	}
 
 	/**
@@ -84,9 +85,7 @@ public class FnSum extends Function {
 	 *             Dynamic error.
 	 * @return Result of fn:sum operation.
 	 */
-	public static ResultSequence sum(ResultSequence arg, AnyAtomicType zero) throws DynamicError {
-
-
+	public static ResultSequence sum(ResultSequence arg, AnyAtomicType zero, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.empty())
 			return zero;
 
@@ -108,7 +107,7 @@ public class FnSum extends Function {
 			if (total == null) {
 				total = (MathPlus)conv; 
 			} else {
-				total = (MathPlus)total.plus(conv).first();
+				total = (MathPlus)total.plus(conv, evaluationContext).first();
 			}
 		}
 		

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnSum.java
@@ -79,7 +79,7 @@ public class FnSum extends Function {
 	/**
 	 * Sum operation.
 	 * 
-	 * @param args
+	 * @param arg
 	 *            Result from the expressions evaluation.
 	 * @throws DynamicError
 	 *             Dynamic error.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsDiv.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsDiv.java
@@ -41,10 +41,10 @@ public class FsDiv extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_div(args);
+		return fs_div(args, evaluationContext);
 	}
 
 	/**
@@ -56,7 +56,7 @@ public class FsDiv extends Function {
 	 *             Dynamic error.
 	 * @return Result of fs:div operation.
 	 */
-	public static ResultSequence fs_div(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_div(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		FsPlus.MathOp<MathDiv> op = new FsPlus.MathOp<MathDiv>() {
 			@Override
 			public Class<? extends MathDiv> getType() {
@@ -64,10 +64,10 @@ public class FsDiv extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathDiv obj, ResultSequence arg) throws DynamicError {
-				return obj.div(arg);
+			public ResultSequence execute(MathDiv obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.div(arg, evaluationContext);
 			}
 		};
-		return FsPlus.do_math_op(args, op);
+		return FsPlus.do_math_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsEq.java
@@ -235,8 +235,8 @@ public class FsEq extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc
-	 *         Dynamic context 
+	 * @param evaluationContext
+	 *         Evaluation context
 	 * @return Result of general equality operation.
 	 */
 	public static ResultSequence fs_eq_general(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
@@ -259,10 +259,6 @@ public class FsEq extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param type
-	 *            type of the arguments.
-	 * @param mname
-	 *            Method name for template simulation.
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -312,10 +308,6 @@ public class FsEq extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param type
-	 *            type of the arguments.
-	 * @param mname
-	 *            Method name for template simulation.
 	 * @param evaluationContext
 	 *             Evaluation context.
 	 * @throws DynamicError

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
@@ -54,7 +54,7 @@ public class FsGe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
+	 * @param evaluationContext current evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -79,8 +79,8 @@ public class FsGe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGe.java
@@ -16,7 +16,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -44,10 +43,10 @@ public class FsGe extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_ge_value(args, ec.getDynamicContext());
+		return fs_ge_value(args, evaluationContext);
 	}
 
 	/**
@@ -60,14 +59,14 @@ public class FsGe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_ge_value(Collection<ResultSequence> args, DynamicContext dc)
+	public static ResultSequence fs_ge_value(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
-		ResultSequence greater = FsGt.fs_gt_value(args, dc);
+		ResultSequence greater = FsGt.fs_gt_value(args, evaluationContext);
 
 		if (((XSBoolean) greater.first()).value())
 			return greater;
 
-		ResultSequence equal = FsEq.fs_eq_value(args, dc);
+		ResultSequence equal = FsEq.fs_eq_value(args, evaluationContext);
 
 		if (((XSBoolean) equal.first()).value())
 			return equal;
@@ -86,14 +85,14 @@ public class FsGe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_ge_general(Collection<ResultSequence> args, DynamicContext dc)
+	public static ResultSequence fs_ge_general(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		FsEq.CmpGeneralOp op = new FsEq.CmpGeneralOp() {
 			@Override
-			public ResultSequence execute(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-				return fs_ge_value(args, dynamicContext);
+			public ResultSequence execute(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+				return fs_ge_value(args, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_general_op(args, op, dc);
+		return FsEq.do_cmp_general_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGt.java
@@ -54,8 +54,8 @@ public class FsGt extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dynamic
-	 *             Dynamic contexet
+	 * @param evaluationContext
+	 *             Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -81,8 +81,8 @@ public class FsGt extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsGt.java
@@ -16,7 +16,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -44,10 +43,10 @@ public class FsGt extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_gt_value(args, ec.getDynamicContext());
+		return fs_gt_value(args, evaluationContext);
 	}
 
 	/**
@@ -61,7 +60,7 @@ public class FsGt extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_gt_value(Collection<ResultSequence> args, DynamicContext dynamic)
+	public static ResultSequence fs_gt_value(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		FsEq.CmpValueOp<CmpGt> op = new FsEq.CmpValueOp<CmpGt>() {
 			@Override
@@ -70,11 +69,11 @@ public class FsGt extends Function {
 			}
 
 			@Override
-			public boolean execute(CmpGt obj, AnyType arg, DynamicContext dynamicContext) throws DynamicError {
-				return obj.gt(arg, dynamicContext);
+			public boolean execute(CmpGt obj, AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.gt(arg, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_value_op(args, op, dynamic);
+		return FsEq.do_cmp_value_op(args, op, evaluationContext);
 	}
 
 	/**
@@ -88,15 +87,15 @@ public class FsGt extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_gt_general(Collection<ResultSequence> args, DynamicContext dc)
+	public static ResultSequence fs_gt_general(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		FsEq.CmpGeneralOp op = new FsEq.CmpGeneralOp() {
 			@Override
-			public ResultSequence execute(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-				return fs_gt_value(args, dynamicContext);
+			public ResultSequence execute(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+				return fs_gt_value(args, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_general_op(args, op, dc);
+		return FsEq.do_cmp_general_op(args, op, evaluationContext);
 	}
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsIDiv.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsIDiv.java
@@ -15,6 +15,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -40,10 +41,10 @@ public class FsIDiv extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_idiv(args);
+		return fs_idiv(args, evaluationContext);
 	}
 
 	/**
@@ -55,7 +56,7 @@ public class FsIDiv extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_idiv(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_idiv(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		FsPlus.MathOp<MathIDiv> op = new FsPlus.MathOp<MathIDiv>() {
 			@Override
 			public Class<? extends MathIDiv> getType() {
@@ -63,10 +64,10 @@ public class FsIDiv extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathIDiv obj, ResultSequence arg) throws DynamicError {
-				return obj.idiv(arg);
+			public ResultSequence execute(MathIDiv obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.idiv(arg, evaluationContext);
 			}
 		};
-		return FsPlus.do_math_op(args, op);
+		return FsPlus.do_math_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
@@ -54,8 +54,8 @@ public class FsLe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param 
-     *         DynamicContext 
+	 * @param evaluationContext
+     *         evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -80,8 +80,8 @@ public class FsLe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLe.java
@@ -16,7 +16,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -44,10 +43,10 @@ public class FsLe extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_le_value(args, ec.getDynamicContext());
+		return fs_le_value(args, evaluationContext);
 	}
 
 	/**
@@ -61,14 +60,14 @@ public class FsLe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_le_value(Collection<ResultSequence> args, DynamicContext dc)
+	public static ResultSequence fs_le_value(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
-		ResultSequence less = FsLt.fs_lt_value(args, dc);
+		ResultSequence less = FsLt.fs_lt_value(args, evaluationContext);
 
 		if (((XSBoolean) less.first()).value())
 			return less;
 
-		ResultSequence equal = FsEq.fs_eq_value(args, dc);
+		ResultSequence equal = FsEq.fs_eq_value(args, evaluationContext);
 
 		if (((XSBoolean) equal.first()).value())
 			return equal;
@@ -87,13 +86,13 @@ public class FsLe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_le_general(Collection<ResultSequence> args, DynamicContext dc) {
+	public static ResultSequence fs_le_general(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		FsEq.CmpGeneralOp op = new FsEq.CmpGeneralOp() {
 			@Override
-			public ResultSequence execute(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-				return fs_le_value(args, dynamicContext);
+			public ResultSequence execute(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+				return fs_le_value(args, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_general_op(args, op, dc);
+		return FsEq.do_cmp_general_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLt.java
@@ -52,8 +52,8 @@ public class FsLt extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param context 
-	 *             Dynamic context
+	 * @param evaluationContext
+	 *             Evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -78,8 +78,8 @@ public class FsLt extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLt.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsLt.java
@@ -16,7 +16,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -42,10 +41,10 @@ public class FsLt extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_lt_value(args, ec.getDynamicContext());
+		return fs_lt_value(args, evaluationContext);
 	}
 
 	/**
@@ -59,7 +58,7 @@ public class FsLt extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_lt_value(Collection<ResultSequence> args, DynamicContext dc) {
+	public static ResultSequence fs_lt_value(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		FsEq.CmpValueOp<CmpLt> op = new FsEq.CmpValueOp<CmpLt>() {
 			@Override
 			public Class<? extends CmpLt> getType() {
@@ -67,11 +66,11 @@ public class FsLt extends Function {
 			}
 
 			@Override
-			public boolean execute(CmpLt obj, AnyType arg, DynamicContext dynamicContext) throws DynamicError {
-				return obj.lt(arg, dynamicContext);
+			public boolean execute(CmpLt obj, AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.lt(arg, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_value_op(args, op, dc);
+		return FsEq.do_cmp_value_op(args, op, evaluationContext);
 	}
 
 	/**
@@ -85,14 +84,14 @@ public class FsLt extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_lt_general(Collection<ResultSequence> args, DynamicContext dc)
+	public static ResultSequence fs_lt_general(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		FsEq.CmpGeneralOp op = new FsEq.CmpGeneralOp() {
 			@Override
-			public ResultSequence execute(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-				return fs_lt_value(args, dynamicContext);
+			public ResultSequence execute(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+				return fs_lt_value(args, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_general_op(args, op, dc);
+		return FsEq.do_cmp_general_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsMinus.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsMinus.java
@@ -16,6 +16,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -43,10 +44,10 @@ public class FsMinus extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_minus(args);
+		return fs_minus(args, evaluationContext);
 	}
 
 	/**
@@ -58,7 +59,7 @@ public class FsMinus extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_minus(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_minus(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		FsPlus.MathOp<MathMinus> op = new FsPlus.MathOp<MathMinus>() {
 			@Override
 			public Class<? extends MathMinus> getType() {
@@ -66,11 +67,11 @@ public class FsMinus extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathMinus obj, ResultSequence arg) throws DynamicError {
-				return obj.minus(arg);
+			public ResultSequence execute(MathMinus obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.minus(arg, evaluationContext);
 			}
 		};
-		return FsPlus.do_math_op(args, op);
+		return FsPlus.do_math_op(args, op, evaluationContext);
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsMod.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsMod.java
@@ -15,6 +15,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -40,10 +41,10 @@ public class FsMod extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_mod(args);
+		return fs_mod(args, evaluationContext);
 	}
 
 	/**
@@ -55,7 +56,7 @@ public class FsMod extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_mod(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_mod(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		FsPlus.MathOp<MathMod> op = new FsPlus.MathOp<MathMod>() {
 			@Override
 			public Class<? extends MathMod> getType() {
@@ -63,10 +64,10 @@ public class FsMod extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathMod obj, ResultSequence arg) throws DynamicError {
-				return obj.mod(arg);
+			public ResultSequence execute(MathMod obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.mod(arg, evaluationContext);
 			}
 		};
-		return FsPlus.do_math_op(args, op);
+		return FsPlus.do_math_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsNe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsNe.java
@@ -53,8 +53,8 @@ public class FsNe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param context 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
@@ -69,8 +69,8 @@ public class FsNe extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param dc 
-	 *             The dynamic context
+	 * @param evaluationContext
+	 *             The evaluation context
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsNe.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsNe.java
@@ -16,7 +16,6 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
 import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -43,10 +42,10 @@ public class FsNe extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_ne_value(args, ec.getDynamicContext());
+		return fs_ne_value(args, evaluationContext);
 	}
 
 	/**
@@ -60,9 +59,9 @@ public class FsNe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_ne_value(Collection<ResultSequence> args, DynamicContext context)
+	public static ResultSequence fs_ne_value(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
-		return FnNot.fn_not(FsEq.fs_eq_value(args, context));
+		return FnNot.fn_not(FsEq.fs_eq_value(args, evaluationContext));
 	}
 
 	/**
@@ -76,15 +75,15 @@ public class FsNe extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_ne_general(Collection<ResultSequence> args, DynamicContext ec)
+	public static ResultSequence fs_ne_general(Collection<ResultSequence> args, EvaluationContext evaluationContext)
 			throws DynamicError {
 		FsEq.CmpGeneralOp op = new FsEq.CmpGeneralOp() {
 			@Override
-			public ResultSequence execute(Collection<ResultSequence> args, DynamicContext dynamicContext) throws DynamicError {
-				return fs_ne_value(args, dynamicContext);
+			public ResultSequence execute(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
+				return fs_ne_value(args, evaluationContext);
 			}
 		};
-		return FsEq.do_cmp_general_op(args, op, ec);
+		return FsEq.do_cmp_general_op(args, op, evaluationContext);
 	}
 
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsPlus.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsPlus.java
@@ -53,10 +53,10 @@ public class FsPlus extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext ec) {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_plus(args);
+		return fs_plus(args, evaluationContext);
 	}
 
 	/**
@@ -64,7 +64,6 @@ public class FsPlus extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param sc 
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of conversion.
@@ -127,12 +126,12 @@ public class FsPlus extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param sc 
+	 * @param evaluationContext
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_plus(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_plus(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		MathOp<MathPlus> op = new MathOp<MathPlus>() {
 			@Override
 			public Class<? extends MathPlus> getType() {
@@ -140,11 +139,11 @@ public class FsPlus extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathPlus obj, ResultSequence arg) throws DynamicError {
-				return obj.plus(arg);
+			public ResultSequence execute(MathPlus obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.plus(arg, evaluationContext);
 			}
 		};
-		return do_math_op(args, op);
+		return do_math_op(args, op, evaluationContext);
 	}
 
 	/**
@@ -178,7 +177,7 @@ public class FsPlus extends Function {
 	public interface MathOp<T> {
 		Class<? extends T> getType();
 
-		ResultSequence execute(T obj, ResultSequence arg) throws DynamicError;
+		ResultSequence execute(T obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 	}
 
 	// voodoo
@@ -187,12 +186,12 @@ public class FsPlus extends Function {
 	 * 
 	 * @param args
 	 *            input arguments.
-	 * @param sc 
+	 * @param evaluationContext
 	 * @throws DynamicError
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public static <T> ResultSequence do_math_op(Collection<ResultSequence> args, MathOp<T> op) throws DynamicError {
+	public static <T> ResultSequence do_math_op(Collection<ResultSequence> args, MathOp<T> op, EvaluationContext evaluationContext) throws DynamicError {
 
 		// sanity check args + convert em
 		if (args.size() != 2)
@@ -218,6 +217,6 @@ public class FsPlus extends Function {
 
 		ResultSequence arg2 = argi.next();
 
-		return op.execute(arg, arg2);
+		return op.execute(arg, arg2, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsTimes.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FsTimes.java
@@ -15,6 +15,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.Collection;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -40,10 +41,10 @@ public class FsTimes extends Function {
 	 * @return Result of evaluation.
 	 */
 	@Override
-	public ResultSequence evaluate(Collection<ResultSequence> args, org.eclipse.wst.xml.xpath2.api.EvaluationContext ec) throws DynamicError {
+	public ResultSequence evaluate(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		assert args.size() >= min_arity() && args.size() <= max_arity();
 
-		return fs_times(args);
+		return fs_times(args, evaluationContext);
 	}
 
 	/**
@@ -55,7 +56,7 @@ public class FsTimes extends Function {
 	 *             Dynamic error.
 	 * @return Result of the operation.
 	 */
-	public static ResultSequence fs_times(Collection<ResultSequence> args) throws DynamicError {
+	public static ResultSequence fs_times(Collection<ResultSequence> args, EvaluationContext evaluationContext) throws DynamicError {
 		FsPlus.MathOp<MathTimes> op = new FsPlus.MathOp<MathTimes>() {
 			@Override
 			public Class<? extends MathTimes> getType() {
@@ -63,10 +64,10 @@ public class FsTimes extends Function {
 			}
 
 			@Override
-			public ResultSequence execute(MathTimes obj, ResultSequence arg) throws DynamicError {
-				return obj.times(arg);
+			public ResultSequence execute(MathTimes obj, ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
+				return obj.times(arg, evaluationContext);
 			}
 		};
-		return FsPlus.do_math_op(args, op);
+		return FsPlus.do_math_op(args, op, evaluationContext);
 	}
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/Function.java
@@ -90,8 +90,8 @@ public abstract class Function implements org.eclipse.wst.xml.xpath2.api.Functio
 	 * 
 	 * @param name
 	 *            QName.
-	 * @param arity
-	 *            the arity of a specific function.
+	 * @param min_arity the minimum arity of a specific function
+	 * @param max_arity the maximum arity of a specific function
 	 */
 	public Function(QName name, int min_arity, int max_arity) {
 		_name = name;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathDiv.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathDiv.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathDiv {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence div(ResultSequence arg) throws DynamicError;
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathIDiv.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathIDiv.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathIDiv {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence idiv(ResultSequence arg) throws DynamicError;
+	public ResultSequence idiv(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathMinus.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathMinus.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathMinus {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence minus(ResultSequence arg) throws DynamicError;
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathMod.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathMod.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathMod {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence mod(ResultSequence arg) throws DynamicError;
+	public ResultSequence mod(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathPlus.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathPlus.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathPlus {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence plus(ResultSequence arg) throws DynamicError;
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathTimes.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/MathTimes.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 
@@ -27,5 +28,5 @@ public interface MathTimes {
 	 *             Dynamic error.
 	 * @return Result of operation.
 	 */
-	public ResultSequence times(ResultSequence arg) throws DynamicError;
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError;
 }

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/NodeType.java
@@ -71,8 +71,6 @@ public abstract class NodeType extends AnyType {
 	 * 
 	 * @param node
 	 *            The Node being represented
-	 * @param document_order
-	 *            The document order
 	 */
 	public NodeType(Node node, TypeModel tm) {
 		_node = node;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/PIType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/PIType.java
@@ -32,8 +32,6 @@ public class PIType extends NodeType {
 	 * 
 	 * @param v
 	 *            The processing instruction this node represents
-	 * @param doc_order
-	 *            The document order
 	 */
 	public PIType(ProcessingInstruction v, TypeModel tm) {
 		super(v, tm);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/QName.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/QName.java
@@ -17,7 +17,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import javax.xml.XMLConstants;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -345,7 +345,7 @@ public class QName extends CtrType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		QName val = NumericType.get_single_type(arg, QName.class);
 		return equals(val);
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSAnyURI.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSAnyURI.java
@@ -17,7 +17,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -120,7 +120,7 @@ public class XSAnyURI extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg instanceof XSAnyURI || arg instanceof XSString) {
 			if (this.string_value().equals(arg.string_value())) {
 				return true;
@@ -138,7 +138,7 @@ public class XSAnyURI extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @since 1.1
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (!(arg instanceof XSAnyURI || arg instanceof XSString)) {
 			throw DynamicError.throw_type_error();	
 		}
@@ -159,7 +159,7 @@ public class XSAnyURI extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @since 1.1
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (!(arg instanceof XSAnyURI || arg instanceof XSString)) {
 			throw DynamicError.throw_type_error();
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBase64Binary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBase64Binary.java
@@ -14,7 +14,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import org.apache.xerces.impl.dv.util.Base64;
 import org.apache.xerces.impl.dv.util.HexBin;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -155,7 +155,7 @@ public class XSBase64Binary extends CtrType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
       String valToCompare = arg.getStringValue();
       
       byte[] value1 = Base64.decode(_value);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -162,7 +162,7 @@ public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 *         comparison
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSBoolean barg = NumericType.get_single_type(arg, XSBoolean.class);
 
 		return value() == barg.value();
@@ -181,7 +181,7 @@ public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 *         comparison
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSBoolean barg = NumericType.get_single_type(arg, XSBoolean.class);
 
 		boolean result = false;
@@ -204,7 +204,7 @@ public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 *         comparison
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSBoolean barg = NumericType.get_single_type(arg, XSBoolean.class);
 
 		boolean result = false;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
@@ -25,7 +25,7 @@ import java.util.TimeZone;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -341,7 +341,7 @@ Cloneable {
 	 *         False otherwise.
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDate val = NumericType.get_single_type(arg, XSDate.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -359,7 +359,7 @@ Cloneable {
 	 *         otherwise.
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDate val = NumericType.get_single_type(arg, XSDate.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -377,7 +377,7 @@ Cloneable {
 	 *         otherwise.
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDate val = NumericType.get_single_type(arg, XSDate.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -413,7 +413,7 @@ Cloneable {
 	 *         minus operation.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 
@@ -495,7 +495,7 @@ Cloneable {
 	 *         minus operation.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
@@ -24,7 +24,7 @@ import java.util.TimeZone;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -756,7 +756,7 @@ Cloneable {
 	 *         point in time. False otherwise.
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDateTime val = NumericType.get_single_type(arg, XSDateTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -775,7 +775,7 @@ Cloneable {
 	 *         supplied. False otherwise.
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDateTime val = NumericType.get_single_type(arg, XSDateTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -794,7 +794,7 @@ Cloneable {
 	 *         supplied. False otherwise.
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDateTime val = NumericType.get_single_type(arg, XSDateTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -840,7 +840,7 @@ Cloneable {
 	 *         minus operation.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 
@@ -852,7 +852,7 @@ Cloneable {
 		}
 
 		if (at instanceof XSDateTime) {
-			return minusXSDateTime(arg);
+			return minusXSDateTime(arg, evaluationContext);
 		}
 
 		if (at instanceof XSYearMonthDuration) {
@@ -866,8 +866,7 @@ Cloneable {
 
 	}
 
-	private ResultSequence minusXSDateTime(ResultSequence arg)
-			throws DynamicError {
+	private ResultSequence minusXSDateTime(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDateTime val = NumericType.get_single_type(arg, XSDateTime.class);
 
 		Calendar thisCal = normalizeCalendar(calendar(), tz());
@@ -925,7 +924,7 @@ Cloneable {
 	 *         minus operation.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 
 import javax.xml.datatype.Duration;
 
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -263,7 +264,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDayTimeDuration.class);
 		
 		double res = value() + val.value();
@@ -282,7 +283,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDayTimeDuration.class);
 
 		double res = value() - val.value();
@@ -301,7 +302,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) throws DynamicError {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence convertedRS = arg;
 		
 		if (arg.size() == 1) {
@@ -332,7 +333,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
@@ -24,7 +24,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -231,7 +231,7 @@ public class XSDecimal extends NumericType {
 	 *         otherwise
 	 */
 	@Override
-	public boolean eq(AnyType at, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType at, EvaluationContext evaluationContext) throws DynamicError {
 		XSDecimal dt = null;
 		if (!(at instanceof XSDecimal)) { 
 			ResultSequence crs = constructor(at);
@@ -258,7 +258,7 @@ public class XSDecimal extends NumericType {
 	 *         one stored. False otherwise
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 		
 		XSDecimal val = get_single_type(carg, XSDecimal.class);
@@ -281,7 +281,7 @@ public class XSDecimal extends NumericType {
 	 *         one stored. False otherwise
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 		XSDecimal val = get_single_type(carg, XSDecimal.class);
 		return (_value.compareTo(val.getValue()) == -1);
@@ -299,7 +299,7 @@ public class XSDecimal extends NumericType {
 	 *         addition.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		// get arg
 		ResultSequence carg = convertResultSequence(arg);
 		Item at = get_single_arg(carg);
@@ -336,7 +336,7 @@ public class XSDecimal extends NumericType {
 	 *         subtraction.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		
 		ResultSequence carg = convertResultSequence(arg);
 
@@ -358,7 +358,7 @@ public class XSDecimal extends NumericType {
 	 *         multiplication.
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDecimal val = get_single_type(carg, XSDecimal.class);
@@ -376,7 +376,7 @@ public class XSDecimal extends NumericType {
 	 *         division.
 	 */
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 			
 		XSDecimal val = get_single_type(carg, XSDecimal.class);
@@ -398,7 +398,7 @@ public class XSDecimal extends NumericType {
 	 *         division.
 	 */
 	@Override
-	public ResultSequence idiv(ResultSequence arg) throws DynamicError {
+	public ResultSequence idiv(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDecimal val = get_single_type(carg, XSDecimal.class);
@@ -421,7 +421,7 @@ public class XSDecimal extends NumericType {
 	 * @return A XSDecimal consisting of the result of the mathematical modulus.
 	 */
 	@Override
-	public ResultSequence mod(ResultSequence arg) throws DynamicError {
+	public ResultSequence mod(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDecimal val = get_single_type(carg, XSDecimal.class);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -259,7 +259,7 @@ public class XSDouble extends NumericType {
 	 * @since 1.1
 	 */
 	@Override
-	public boolean eq(AnyType aa, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType aa, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence crs = constructor(aa);
 		
 		if (crs.empty()) {
@@ -292,7 +292,7 @@ public class XSDouble extends NumericType {
 	 *         one stored. False otherwise
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 		
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -317,7 +317,7 @@ public class XSDouble extends NumericType {
 	 *         one stored. False otherwise
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -334,7 +334,7 @@ public class XSDouble extends NumericType {
 	 * @return A XSDouble consisting of the result of the mathematical addition.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		Item at = get_single_arg(carg);
 		
@@ -371,7 +371,7 @@ public class XSDouble extends NumericType {
 	 *         subtraction.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -390,7 +390,7 @@ public class XSDouble extends NumericType {
 	 *         multiplication.
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) throws DynamicError {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -406,7 +406,7 @@ public class XSDouble extends NumericType {
 	 * @return A XSDouble consisting of the result of the mathematical division.
 	 */
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -423,7 +423,7 @@ public class XSDouble extends NumericType {
 	 *         division.
 	 */
 	@Override
-	public ResultSequence idiv(ResultSequence arg) throws DynamicError {
+	public ResultSequence idiv(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = get_single_type(carg, XSDouble.class);
@@ -450,7 +450,7 @@ public class XSDouble extends NumericType {
 	 * @return A XSDouble consisting of the result of the mathematical modulus.
 	 */
 	@Override
-	public ResultSequence mod(ResultSequence arg) throws DynamicError {
+	public ResultSequence mod(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSDouble val = get_single_type(carg, XSDouble.class);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDuration.java
@@ -13,7 +13,7 @@
 
 package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -236,7 +236,7 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDuration.class);
 
 		return value() == val.value();
@@ -252,7 +252,7 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDayTimeDuration.class);
 
 		return value() < val.value();
@@ -268,7 +268,7 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDayTimeDuration.class);
 
 		return value() > val.value();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -224,7 +224,7 @@ public class XSFloat extends NumericType {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType aa, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType aa, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(aa);
 		if (!(carg instanceof XSFloat))
 			throw DynamicError.throw_type_error();
@@ -254,7 +254,7 @@ public class XSFloat extends NumericType {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 		return float_value() > val.float_value();
@@ -270,7 +270,7 @@ public class XSFloat extends NumericType {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 		return float_value() < val.float_value();
@@ -285,7 +285,7 @@ public class XSFloat extends NumericType {
 	 * @return A XSFloat consisting of the result of the mathematical addition.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		Item at = get_single_arg(carg);
 		if (!(at instanceof XSFloat))
@@ -305,7 +305,7 @@ public class XSFloat extends NumericType {
 	 *         subtraction.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = constructor(arg);
 		Item at = get_single_arg(carg);
 		if (!(at instanceof XSFloat))
@@ -325,7 +325,7 @@ public class XSFloat extends NumericType {
 	 *         multiplication.
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) throws DynamicError {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = constructor(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 		return new XSFloat(float_value() * val.float_value());
@@ -340,7 +340,7 @@ public class XSFloat extends NumericType {
 	 * @return A XSFloat consisting of the result of the mathematical division.
 	 */
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 		return new XSFloat(float_value() / val.float_value());
@@ -356,7 +356,7 @@ public class XSFloat extends NumericType {
 	 *         division.
 	 */
 	@Override
-	public ResultSequence idiv(ResultSequence arg) throws DynamicError {
+	public ResultSequence idiv(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 
@@ -384,7 +384,7 @@ public class XSFloat extends NumericType {
 	 * @return A XSFloat consisting of the result of the mathematical modulus.
 	 */
 	@Override
-	public ResultSequence mod(ResultSequence arg) throws DynamicError {
+	public ResultSequence mod(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSFloat val = get_single_type(carg, XSFloat.class);
 		return new XSFloat(float_value() % val.float_value());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
@@ -19,7 +19,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -305,7 +305,7 @@ public class XSGDay extends CalendarType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSGDay val = NumericType.get_single_type(arg, XSGDay.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonth.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonth.java
@@ -18,7 +18,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -300,7 +300,7 @@ public class XSGMonth extends CalendarType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSGMonth val = NumericType.get_single_type(arg, XSGMonth.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonthDay.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonthDay.java
@@ -20,7 +20,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -321,7 +321,7 @@ public class XSGMonthDay extends CalendarType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSGMonthDay val = NumericType.get_single_type(arg, XSGMonthDay.class);
 
 		return calendar().equals(val.calendar());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
@@ -18,7 +18,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -278,7 +278,7 @@ public class XSGYear extends CalendarType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSGYear val = NumericType.get_single_type(arg, XSGYear.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYearMonth.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYearMonth.java
@@ -18,7 +18,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -302,7 +302,7 @@ public class XSGYearMonth extends CalendarType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSGYearMonth val = NumericType.get_single_type(arg, XSGYearMonth.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSHexBinary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSHexBinary.java
@@ -15,7 +15,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import org.apache.xerces.impl.dv.util.Base64;
 import org.apache.xerces.impl.dv.util.HexBin;
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
@@ -168,7 +168,7 @@ public class XSHexBinary extends CtrType implements CmpEq {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
       String valToCompare = arg.getStringValue();
       
       byte[] value1 = HexBin.decode(_value);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Iterator;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -251,7 +251,7 @@ public class XSInteger extends XSDecimal {
 	 *         addition.
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		Item at = get_single_arg(carg);
 		if (!(at instanceof XSInteger))
@@ -289,7 +289,7 @@ public class XSInteger extends XSDecimal {
 	 *         subtraction.
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		XSInteger val = get_single_type(carg, XSInteger.class);
 		
@@ -306,7 +306,7 @@ public class XSInteger extends XSDecimal {
 	 *         multiplication.
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) throws DynamicError {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSInteger val = get_single_type(carg, XSInteger.class);
@@ -323,7 +323,7 @@ public class XSInteger extends XSDecimal {
 	 * @return A XSInteger consisting of the result of the mathematical modulus.
 	 */
 	@Override
-	public ResultSequence mod(ResultSequence arg) throws DynamicError {
+	public ResultSequence mod(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 
 		XSInteger val = get_single_type(carg, XSInteger.class);
@@ -357,7 +357,7 @@ public class XSInteger extends XSDecimal {
 	 * @see org.eclipse.wst.xml.xpath2.processor.internal.types.XSDecimal#gt(org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType)
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
         XSInteger val = get_single_type(carg, XSInteger.class);
         
@@ -378,7 +378,7 @@ public class XSInteger extends XSDecimal {
 	 * @see org.eclipse.wst.xml.xpath2.processor.internal.types.XSDecimal#lt(org.eclipse.wst.xml.xpath2.processor.internal.types.AnyType)
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		Item carg = convertArg(arg);
         XSInteger val = get_single_type(carg, XSInteger.class);
         
@@ -388,7 +388,7 @@ public class XSInteger extends XSDecimal {
 	}
 	
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence carg = convertResultSequence(arg);
 		
 		XSDecimal val = get_single_type(carg, XSDecimal.class);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSString.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSString.java
@@ -17,7 +17,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import java.math.BigInteger;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -118,14 +118,14 @@ public class XSString extends CtrType implements CmpEq, CmpGt, CmpLt {
 	// comparisons
 
 	// 666 indicates death [compare returned empty seq]
-	private int do_compare(AnyType arg, DynamicContext dc) throws DynamicError {
+	private int do_compare(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 
 		// XXX: This can't happen, I guess
 		if (arg == null) return 666;
 
 		XSString comparand = arg instanceof XSString ? (XSString)arg : new XSString(arg.getStringValue());
 		
-		BigInteger result = FnCompare.compare_string(dc.getCollationProvider().getDefaultCollation(), this, comparand, dc);
+		BigInteger result = FnCompare.compare_string(evaluationContext.getDynamicContext().getCollationProvider().getDefaultCollation(), this, comparand, evaluationContext);
 
 		return result.intValue();
 	}
@@ -141,8 +141,8 @@ public class XSString extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
-		int cmp = do_compare(arg, dynamicContext);
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
+		int cmp = do_compare(arg, evaluationContext);
 
 		// XXX im not sure what to do here!!! because eq has to return
 		// something i fink....
@@ -163,8 +163,8 @@ public class XSString extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
-		int cmp = do_compare(arg, context);
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
+		int cmp = do_compare(arg, evaluationContext);
 
 		assert cmp != 666;
 
@@ -182,8 +182,8 @@ public class XSString extends CtrType implements CmpEq, CmpGt, CmpLt {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
-		int cmp = do_compare(arg, context);
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
+		int cmp = do_compare(arg, evaluationContext);
 
 		assert cmp != 666;
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
@@ -24,7 +24,7 @@ import java.util.TimeZone;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -322,7 +322,7 @@ Cloneable {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSTime val = NumericType.get_single_type(arg, XSTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -339,7 +339,7 @@ Cloneable {
 	 *         represented by the time stored. False otherwise
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSTime val = NumericType.get_single_type(arg, XSTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -356,7 +356,7 @@ Cloneable {
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSTime val = NumericType.get_single_type(arg, XSTime.class);
 		Calendar thiscal = normalizeCalendar(calendar(), tz());
 		Calendar thatcal = normalizeCalendar(val.calendar(), val.tz());
@@ -377,7 +377,7 @@ Cloneable {
 	 * @return A ResultSequence representing the result of the subtraction
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 
@@ -436,7 +436,7 @@ Cloneable {
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSDuration val = NumericType.get_single_type(arg, XSDayTimeDuration.class);
 
 		try {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
@@ -18,7 +18,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.types;
 
 import java.math.BigDecimal;
 
-import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.EvaluationContext;
 import org.eclipse.wst.xml.xpath2.api.Item;
 import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
@@ -291,7 +291,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean eq(AnyType arg, DynamicContext dynamicContext) throws DynamicError {
+	public boolean eq(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg instanceof XSDayTimeDuration) {
 			XSDayTimeDuration dayTimeDuration = (XSDayTimeDuration)arg;
 			return (monthValue() == 0 && dayTimeDuration.value() == 0.0);
@@ -300,7 +300,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 			return monthValue() == yearMonthDuration.monthValue();
 		}
 		XSDuration val = NumericType.get_single_type(arg, XSDuration.class);
-		return super.eq(val, dynamicContext);
+		return super.eq(val, evaluationContext);
 	}
 
 	/**
@@ -313,7 +313,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean lt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean lt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSYearMonthDuration val = NumericType.get_single_type(arg, XSYearMonthDuration.class);
 
 		return monthValue() < val.monthValue();
@@ -329,7 +329,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public boolean gt(AnyType arg, DynamicContext context) throws DynamicError {
+	public boolean gt(AnyType arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSYearMonthDuration val = NumericType.get_single_type(arg, XSYearMonthDuration.class);
 
 		return monthValue() > val.monthValue();
@@ -346,7 +346,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence plus(ResultSequence arg) throws DynamicError {
+	public ResultSequence plus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSYearMonthDuration val = NumericType.get_single_type(arg, XSYearMonthDuration.class);
 
 		int res = monthValue() + val.monthValue();
@@ -365,7 +365,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence minus(ResultSequence arg) throws DynamicError {
+	public ResultSequence minus(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		XSYearMonthDuration val = NumericType.get_single_type(arg, XSYearMonthDuration.class);
 
 		int res = monthValue() - val.monthValue();
@@ -384,7 +384,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence times(ResultSequence arg) throws DynamicError {
+	public ResultSequence times(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		ResultSequence convertedRS = arg;		
 		if (arg.size() == 1) {
 			Item argValue = arg.first();
@@ -419,7 +419,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 	 * @throws DynamicError
 	 */
 	@Override
-	public ResultSequence div(ResultSequence arg) throws DynamicError {
+	public ResultSequence div(ResultSequence arg, EvaluationContext evaluationContext) throws DynamicError {
 		if (arg.size() != 1)
 			throw DynamicError.throw_type_error();
 


### PR DESCRIPTION
Information about static context is required for some upcoming bug fixes. This
change separates the tedious work of ensuring operators and other internal
implementation methods have access to the information prior to reviewing the
specific bug fixes.
