### PR TITLE
Atomize arguments to constructor functions

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/CalendarType.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/CalendarType.java
@@ -43,20 +43,6 @@ public abstract class CalendarType extends CtrType {
 		
 	}
 
-	protected boolean isGDataType(AnyType aat) {
-		if (! (aat instanceof AnyAtomicType)) return false;
-	
-		String type = aat.string_type();
-		if (type.equals("xs:gMonthDay") ||
-			type.equals("xs:gDay") ||
-			type.equals("xs:gMonth") ||
-			type.equals("xs:gYear") ||
-			type.equals("xs:gYearMonth")) {
-			return true;
-		}
-		return false;
-	}
-	
 	@Override
 	public Object getNativeValue() {
 		return _datatypeFactory.newXMLGregorianCalendar((GregorianCalendar)calendar());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/QName.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/QName.java
@@ -22,6 +22,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -136,7 +137,7 @@ public class QName extends CtrType implements CmpEq {
 		if (arg.empty())
 			throw DynamicError.throw_type_error();
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 
 		if (!(aat instanceof XSString) && !(aat instanceof QName))
 			throw DynamicError.throw_type_error();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSAnyURI.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSAnyURI.java
@@ -25,6 +25,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -98,7 +99,7 @@ public class XSAnyURI extends CtrType implements CmpEq, CmpGt, CmpLt {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyType aat = (AnyType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 
 		if (!(aat.string_type().equals("xs:string")
 				|| aat.string_type().equals(XS_ANY_URI) || aat.string_type()

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBase64Binary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBase64Binary.java
@@ -20,6 +20,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -102,15 +103,9 @@ public class XSBase64Binary extends CtrType implements CmpEq {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof XSDuration ||
-			aat instanceof CalendarType || aat instanceof XSBoolean ||
-			aat instanceof XSAnyURI) {
-			throw DynamicError.invalidType();
-		}
-
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
-			throw DynamicError.cant_cast(null);
+			throw DynamicError.invalidType();
 		}
 		
 		String str_value = aat.getStringValue();
@@ -132,16 +127,12 @@ public class XSBase64Binary extends CtrType implements CmpEq {
 		}
 	}
 
-	private boolean isCastable(AnyAtomicType aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic) {
-			return true;
-		}
-		
-		if (aat instanceof XSBase64Binary || aat instanceof XSHexBinary) {
-			return true;
-		}
-		
-		return false;
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.7 (Casting to xs:base64Binary and xs:hexBinary)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSBase64Binary
+				|| aat instanceof XSHexBinary;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSBoolean.java
@@ -23,6 +23,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -118,14 +119,17 @@ public class XSBoolean extends CtrType implements CmpEq, CmpGt, CmpLt {
 		if (arg.empty())
 		  return ResultBuffer.EMPTY;
 		
-		Item anyType = arg.first();
-		
-		if (anyType instanceof XSDuration || anyType instanceof CalendarType ||
-			anyType instanceof XSBase64Binary || anyType instanceof XSHexBinary ||
-			anyType instanceof XSAnyURI) {
+		AnyType anyType = FnData.atomize(arg.first());
+		// From 17.1.6 (Casting to xs:boolean)
+		if (!(anyType instanceof XSString
+				|| anyType instanceof XSUntypedAtomic
+				|| anyType instanceof XSBoolean
+				|| anyType instanceof XSFloat
+				|| anyType instanceof XSDouble
+				|| anyType instanceof XSDecimal)) {
 			throw DynamicError.invalidType();
 		}
-		
+
 		String str_value = anyType.getStringValue();
 		
 		

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
@@ -34,6 +34,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathMinus;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathPlus;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
@@ -159,8 +160,7 @@ Cloneable {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		Item aat = arg.first();
-
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
 			throw DynamicError.invalidType();
 		}
@@ -174,27 +174,11 @@ Cloneable {
 	}
 
 	private boolean isCastable(Item aat) {
-
-		// We might be able to cast these.
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic
-				|| aat instanceof NodeType) {
-			return true;
-		}
-
-		if (aat instanceof XSTime) {
-			return false;
-		}
-
-		if (aat instanceof XSDateTime) {
-			return true;
-
-		}
-
-		if (aat instanceof XSDate) {
-			return true;
-		}
-
-		return false;
+		// From 17.1.5 (Casting to date and time types)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDateTime
+				|| aat instanceof XSDate;
 	}
 
 	private XSDate castDate(Item aat) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
@@ -33,6 +33,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathMinus;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathPlus;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
@@ -505,16 +506,9 @@ Cloneable {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof XSDuration
-				|| aat instanceof XSTime || isGDataType(aat)
-				|| aat instanceof XSBoolean || aat instanceof XSBase64Binary
-				|| aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
-			throw DynamicError.invalidType();
-		}
-
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
-			throw DynamicError.cant_cast(null);
+			throw DynamicError.invalidType();
 		}
 
 		CalendarType dt = castDateTime(aat);
@@ -525,23 +519,15 @@ Cloneable {
 		return dt;
 	}
 
-	private boolean isCastable(AnyAtomicType aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic) {
-			return true;
-		}
-
-		if (aat instanceof XSTime) {
-			return false;
-		}
-
-		if (aat instanceof XSDate || aat instanceof XSDateTime) {
-			return true;
-		}
-
-		return false;
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.5 (Casting to date and time types)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDateTime
+				|| aat instanceof XSDate;
 	}
 
-	private CalendarType castDateTime(AnyAtomicType aat) {
+	private CalendarType castDateTime(AnyType aat) {
 		if (aat instanceof XSDate) {
 			XSDate date = (XSDate) aat;
 			return new XSDateTime(date.calendar(), date.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDayTimeDuration.java
@@ -29,6 +29,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathDiv;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathMinus;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathPlus;
@@ -108,10 +109,11 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 	
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof CalendarType ||
-			aat instanceof XSBoolean || aat instanceof XSBase64Binary ||
-			aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		// From 17.1.4 (Casting to duration types)
+		if (!(aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDuration)) {
 			throw DynamicError.invalidType();
 		}
 
@@ -127,7 +129,7 @@ public class XSDayTimeDuration extends XSDuration implements CmpEq, CmpLt,
 		return dtd;
 	}
 	
-	private XSDuration castDayTimeDuration(AnyAtomicType aat) {
+	private XSDuration castDayTimeDuration(AnyType aat) {
 		if (aat instanceof XSDuration) {
 			XSDuration duration = (XSDuration) aat;
 			return new XSDayTimeDuration(duration.days(), duration.hours(), duration.minutes(), duration.seconds(), duration.negative());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDecimal.java
@@ -30,6 +30,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -125,14 +126,17 @@ public class XSDecimal extends NumericType {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		Item aat = arg.first();
-		
-		if (aat instanceof XSDuration || aat instanceof CalendarType ||
-			aat instanceof XSBase64Binary || aat instanceof XSHexBinary ||
-			aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		// From 17.1.3.3 (Casting to xs:decimal)
+		if (!(aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSFloat
+				|| aat instanceof XSDouble
+				|| aat instanceof XSDecimal
+				|| aat instanceof XSBoolean)) {
 			throw DynamicError.invalidType();
 		}
-		
+
 		if (!isLexicalValue(aat.getStringValue())) {
 			throw DynamicError.invalidLexicalValue(null);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDouble.java
@@ -28,6 +28,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -115,16 +116,9 @@ public class XSDouble extends NumericType {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		Item aat = arg.first();
-
-		if (aat instanceof XSDuration || aat instanceof CalendarType ||
-			aat instanceof XSBase64Binary || aat instanceof XSHexBinary ||
-			aat instanceof XSAnyURI) {
-			throw DynamicError.invalidType();
-		}
-		
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
-			throw DynamicError.cant_cast(null);
+			throw DynamicError.invalidType();
 		}
 
 		XSDouble d = castDouble(aat);
@@ -134,18 +128,17 @@ public class XSDouble extends NumericType {
 
 		return d;
 	}
-	
-	private boolean isCastable(Item aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic ||
-			aat instanceof NodeType) {
-			return true;
-		}
-		if (aat instanceof XSBoolean || aat instanceof NumericType) {
-			return true;
-		}
-		return false;
+
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.3.2 (Casting to xs:double)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSFloat
+				|| aat instanceof XSDouble
+				|| aat instanceof XSDecimal
+				|| aat instanceof XSBoolean;
 	}
-	
+
 	private XSDouble castDouble(Item aat) {
 		if (aat instanceof XSBoolean) {
 			if (aat.getStringValue().equals("true")) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDuration.java
@@ -21,6 +21,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -330,11 +331,11 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		
-		if (aat instanceof NumericType || aat instanceof CalendarType ||
-			aat instanceof XSBoolean || aat instanceof XSBase64Binary ||
-			aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		// From 17.1.4 (Casting to duration types)
+		if (!(aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDuration)) {
 			throw DynamicError.invalidType();
 		}
 
@@ -350,7 +351,7 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 		return duration;
 	}
 
-	private XSDuration castDuration(AnyAtomicType aat) {
+	private XSDuration castDuration(AnyType aat) {
 		if (aat instanceof XSDuration) {
 			XSDuration duration = (XSDuration) aat;
 			return new XSDuration(duration.year(), duration.month(), duration.days(), duration.hours(), duration.minutes(), duration.seconds(), duration.negative());
@@ -490,7 +491,7 @@ public class XSDuration extends CtrType implements CmpEq, CmpLt, CmpGt, Cloneabl
 		return _month;
 	}
 
-	protected boolean isCastable(AnyAtomicType aat) {
+	protected boolean isCastable(AnyType aat) {
 		String value = aat.getStringValue(); // get this once so we don't recreate everytime.
 		String type = aat.string_type();
 		if (type.equals("xs:string") || type.equals("xs:untypedAtomic")) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSEntity.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSEntity.java
@@ -17,6 +17,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -64,7 +65,7 @@ public class XSEntity extends XSNCName {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!isConstraintSatisfied(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSFloat.java
@@ -28,6 +28,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -167,21 +168,10 @@ public class XSFloat extends NumericType {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyType aat = (AnyType) arg.first();
-		
-		if (aat instanceof XSDuration || aat instanceof CalendarType ||
-			aat instanceof XSBase64Binary || aat instanceof XSHexBinary ||
-			aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		if (!isCastable(aat)) {
 			throw DynamicError.invalidType();
 		}
-		
-		if (!(aat.string_type().equals("xs:string") || aat instanceof NodeType ||
-			aat.string_type().equals("xs:untypedAtomic") ||
-			aat.string_type().equals("xs:boolean") ||
-			aat instanceof NumericType)) {
-			throw DynamicError.cant_cast(null);
-		}
-		
 
 		try {
 			float f;
@@ -203,6 +193,16 @@ public class XSFloat extends NumericType {
 			throw DynamicError.cant_cast(null, e);
 		}
 
+	}
+
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.3.1 (Casting to xs:float)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSFloat
+				|| aat instanceof XSDouble
+				|| aat instanceof XSDecimal
+				|| aat instanceof XSBoolean;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
@@ -25,6 +25,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -150,16 +151,9 @@ public class XSGDay extends CalendarType implements CmpEq {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof XSDuration ||
-			aat instanceof XSTime || isGDataType(aat) ||
-			aat instanceof XSBoolean || aat instanceof XSBase64Binary ||
-			aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
-			throw DynamicError.invalidType();
-		}
-
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
-			throw DynamicError.cant_cast(null);
+			throw DynamicError.invalidType();
 		}
 		
 		XSGDay val = castGDay(aat);
@@ -169,37 +163,17 @@ public class XSGDay extends CalendarType implements CmpEq {
 
 		return val;
 	}
-	
-	private boolean isCastable(AnyAtomicType aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic) {
-			return true;
-		}
-		
-		if (aat instanceof XSTime) {
-			return false;
-		}
-		
-		if (aat instanceof XSDate || aat instanceof XSDateTime ||
-			aat instanceof XSGDay) {
-			return true;
-		}
-		
-		return false;
+
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.5 (Casting to date and time types)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDateTime
+				|| aat instanceof XSDate
+				|| aat instanceof XSGDay;
 	}
-	
-	protected boolean isGDataType(AnyAtomicType aat) {
-		String type = aat.string_type();
-		if (type.equals("xs:gMonthDay") ||
-			type.equals("xs:gMonth") ||
-			type.equals("xs:gYear") ||
-			type.equals("xs:gYearMonth")) {
-			return true;
-		}
-		return false;
-	}
-	
-	
-	private XSGDay castGDay(AnyAtomicType aat) {
+
+	private XSGDay castGDay(AnyType aat) {
 		if (aat instanceof XSGDay) {
 			XSGDay gday = (XSGDay) aat;
 			return new XSGDay(gday.calendar(), gday.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
@@ -24,6 +24,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -120,18 +121,11 @@ public class XSGYear extends CalendarType implements CmpEq {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof XSDuration ||
-			aat instanceof XSTime || isGDataType(aat) ||
-			aat instanceof XSBoolean || aat instanceof XSBase64Binary ||
-			aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		if (!isCastable(aat)) {
 			throw DynamicError.invalidType();
 		}
-		
-		if (!isCastable(aat)) {
-			throw DynamicError.cant_cast(null);
-		}
-		
+
 		XSGYear val = castGYear(aat);
 
 		if (val == null)
@@ -139,36 +133,17 @@ public class XSGYear extends CalendarType implements CmpEq {
 
 		return val;
 	}
-	
-	protected boolean isGDataType(AnyAtomicType aat) {
-		String type = aat.string_type();
-		if (type.equals("xs:gMonthDay") ||
-			type.equals("xs:gDay") ||
-			type.equals("xs:gMonth") ||
-			type.equals("xs:gYearMonth")) {
-			return true;
-		}
-		return false;
+
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.5 (Casting to date and time types)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDateTime
+				|| aat instanceof XSDate
+				|| aat instanceof XSGYear;
 	}
-	
-	private boolean isCastable(AnyAtomicType aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic) {
-			return true;
-		}
-		
-		if (aat instanceof XSTime) {
-			return false;
-		}
-		
-		if (aat instanceof XSDate || aat instanceof XSDateTime || 
-			aat instanceof XSGYear) {
-			return true;
-		}
-		
-		return false;
-	}
-	
-	private XSGYear castGYear(AnyAtomicType aat) {
+
+	private XSGYear castGYear(AnyType aat) {
 		if (aat instanceof XSGYear) {
 			XSGYear gy = (XSGYear) aat;
 			return new XSGYear(gy.calendar(), gy.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSHexBinary.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSHexBinary.java
@@ -21,6 +21,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -102,22 +103,12 @@ public class XSHexBinary extends CtrType implements CmpEq {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof XSDuration ||
-			aat instanceof CalendarType || aat instanceof XSBoolean ||
-			aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		if (!isCastable(aat)) {
 			throw DynamicError.invalidType();
 		}
 
 		String str_value = aat.getStringValue();
-		
-		if (!(aat instanceof XSHexBinary ||
-				  aat instanceof XSString ||
-				  aat instanceof XSUntypedAtomic ||
-				  aat instanceof XSBase64Binary)) {
-				throw DynamicError.cant_cast(null);
-			}
-		
 		if (aat instanceof XSUntypedAtomic || aat instanceof XSString) {
 			String[] nonHexValues = null;
 			try {
@@ -155,6 +146,14 @@ public class XSHexBinary extends CtrType implements CmpEq {
 		  // invalid hexBinary string
 		  throw DynamicError.throw_type_error();	
 		}
+	}
+
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.7 (Casting to xs:base64Binary and xs:hexBinary)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSBase64Binary
+				|| aat instanceof XSHexBinary;
 	}
 
 	/**

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSID.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSID.java
@@ -16,6 +16,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /*
@@ -50,7 +51,7 @@ public class XSID extends XSNCName {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!isConstraintSatisfied(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSIDREF.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSIDREF.java
@@ -16,6 +16,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /*
@@ -50,7 +51,7 @@ public class XSIDREF extends XSNCName {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!isConstraintSatisfied(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSInteger.java
@@ -28,6 +28,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -128,19 +129,21 @@ public class XSInteger extends XSDecimal {
 
 		// the function conversion rules apply here too. Get the argument
 		// and convert it's string value to an integer.
-		Item aat = arg.first();
-
-		if (aat instanceof XSDuration || aat instanceof CalendarType ||
-			aat instanceof XSBase64Binary || aat instanceof XSHexBinary ||
-			aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		// From 17.1.3.4 (Casting to xs:integer)
+		if (!(aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSFloat
+				|| aat instanceof XSDouble
+				|| aat instanceof XSDecimal
+				|| aat instanceof XSBoolean)) {
 			throw DynamicError.invalidType();
 		}
-		
+
 		if (!isCastable(aat)) {
 			throw DynamicError.cant_cast(null);
 		}
 
-		
 		try {
 			BigInteger bigInt = castInteger(aat);
 			if (getMinValue() != null && bigInt.compareTo(getMinValue()) < 0) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNCName.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNCName.java
@@ -18,6 +18,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -77,7 +78,7 @@ public class XSNCName extends XSName {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!isConstraintSatisfied(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNMTOKEN.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNMTOKEN.java
@@ -18,6 +18,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -77,7 +78,7 @@ public class XSNMTOKEN extends XSToken {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!XMLChar.isValidNmtoken(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSName.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSName.java
@@ -18,6 +18,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -77,7 +78,7 @@ public class XSName extends XSToken {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		String strValue = aat.getStringValue();
 		
 		if (!XMLChar.isValidName(strValue)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNormalizedString.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSNormalizedString.java
@@ -17,6 +17,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -77,7 +78,7 @@ public class XSNormalizedString extends XSString {
 		if (arg.empty())
 		   return ResultBuffer.EMPTY;
 
-		Item aat = arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 
 		String srcString = aat.getStringValue();
 		if (!isSatisfiesConstraints(srcString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSString.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSString.java
@@ -27,6 +27,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.FnCompare;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -109,8 +110,7 @@ public class XSString extends CtrType implements CmpEq, CmpGt, CmpLt {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		//AnyAtomicType aat = (AnyAtomicType) arg.first();
-		Item aat = arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 
 		return new XSString(aat.getStringValue());
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSTime.java
@@ -33,6 +33,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathMinus;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathPlus;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
@@ -135,11 +136,11 @@ Cloneable {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		if (!isCastable(aat)) {
 			throw DynamicError.invalidType();
 		}
-		
+
 		CalendarType t = castTime(aat);
 
 		if (t == null)
@@ -148,22 +149,15 @@ Cloneable {
 		return t;
 	} 
 
-	private boolean isCastable(AnyAtomicType aat) {
-		if (aat instanceof XSString || aat instanceof XSUntypedAtomic) {
-			return true;
-		}
-		
-		if (aat instanceof XSDateTime) {
-			return true;
-		}
-		
-		if (aat instanceof XSTime) {
-			return true;
-		}
-		return false;
+	private boolean isCastable(AnyType aat) {
+		// From 17.1.5 (Casting to date and time types)
+		return aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDateTime
+				|| aat instanceof XSTime;
 	}
-	
-	private CalendarType castTime(AnyAtomicType aat) {
+
+	private CalendarType castTime(AnyType aat) {
 		if (aat instanceof XSTime) {
 			XSTime time = (XSTime) aat;
 			return new XSTime(time.calendar(), time.tz());

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSToken.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSToken.java
@@ -16,6 +16,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -76,7 +77,7 @@ public class XSToken extends XSNormalizedString {
 		if (arg.empty())
 		   return ResultBuffer.EMPTY;
 
-		Item aat = arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 
 		String srcString = aat.getStringValue();
 		if (!isSatisfiesConstraints(srcString)) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSUntypedAtomic.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSUntypedAtomic.java
@@ -17,6 +17,7 @@ import org.eclipse.wst.xml.xpath2.api.ResultBuffer;
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.api.typesystem.TypeDefinition;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.builtin.BuiltinTypeLibrary;
 
 /**
@@ -69,7 +70,7 @@ public class XSUntypedAtomic extends CtrType {
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
+		AnyType aat = FnData.atomize(arg.first());
 		return new XSUntypedAtomic(aat.getStringValue());
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSYearMonthDuration.java
@@ -27,6 +27,7 @@ import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpEq;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpGt;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.CmpLt;
+import org.eclipse.wst.xml.xpath2.processor.internal.function.FnData;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathDiv;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathMinus;
 import org.eclipse.wst.xml.xpath2.processor.internal.function.MathPlus;
@@ -190,12 +191,14 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 		if (arg.empty())
 			return ResultBuffer.EMPTY;
 
-		AnyAtomicType aat = (AnyAtomicType) arg.first();
-		if (aat instanceof NumericType || aat instanceof CalendarType ||
-			aat instanceof XSBoolean || aat instanceof XSBase64Binary ||
-			aat instanceof XSHexBinary || aat instanceof XSAnyURI) {
+		AnyType aat = FnData.atomize(arg.first());
+		// From 17.1.4 (Casting to duration types)
+		if (!(aat instanceof XSString
+				|| aat instanceof XSUntypedAtomic
+				|| aat instanceof XSDuration)) {
 			throw DynamicError.invalidType();
 		}
+
 
 		if (!isCastable(aat)) {
 			throw DynamicError.cant_cast(null);
@@ -209,7 +212,7 @@ public class XSYearMonthDuration extends XSDuration implements CmpEq, CmpLt,
 		return ymd;
 	}
 	
-	private XSDuration castYearMonthDuration(AnyAtomicType aat) {
+	private XSDuration castYearMonthDuration(AnyType aat) {
 		if (aat instanceof XSDuration) {
 			XSDuration duration = (XSDuration) aat;
 			return new XSYearMonthDuration(duration.year(), duration.month(), duration.negative());


### PR DESCRIPTION
This commit also updates constructor functions to throw XPTY0004 as expected.

Fixes #74
