### PR TITLE
Exclude XQuery-specific tests

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/test/catalog/cat/CombinedErrorCodes.xml
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/test/catalog/cat/CombinedErrorCodes.xml
@@ -3,7 +3,7 @@
       <title>Single error code for extra features</title>
       <description/>
    </GroupInfo>
-   <test-case is-XPath2="true" name="combined-errors-1" FilePath="OptionalFeatureErrors/CombinedErrorCodes/" scenario="standard" Creator="Carmelo Montanez">
+   <test-case is-XPath2="false" name="combined-errors-1" FilePath="OptionalFeatureErrors/CombinedErrorCodes/" scenario="standard" Creator="Carmelo Montanez">
       <description>Evaluates simple module import to generate error code if feature not supported.</description>
       <spec-citation spec="XQuery" section-number="5.2.5" section-title="Module Feature" section-pointer="id-module-feature"/>
       <query name="combined-errors-1" date="2006-06-06"/>
@@ -13,7 +13,7 @@
       <output-file role="principal" compare="Text">combined-errors-1.txt</output-file>
       <expected-error>XQST0016</expected-error>
    </test-case>
-   <test-case is-XPath2="true" name="combined-errors-2" FilePath="OptionalFeatureErrors/CombinedErrorCodes/" scenario="standard" Creator="Carmelo Montanez">
+   <test-case is-XPath2="false" name="combined-errors-2" FilePath="OptionalFeatureErrors/CombinedErrorCodes/" scenario="standard" Creator="Carmelo Montanez">
       <description>Evaluates simple schema import to generate error code if feature not supported.</description>
       <spec-citation spec="XQuery" section-number="5.2.1" section-title="Schema Import Feature" section-pointer="id-schema-import-feature"/>
       <query name="combined-errors-2" date="2006-06-06"/>

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/test/catalog/cat/ForExprWithout.xml
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/test/catalog/cat/ForExprWithout.xml
@@ -255,7 +255,7 @@
       <input-file role="principal-data" variable="input-context">fsx</input-file>
       <output-file role="principal" compare="Fragment">ForExpr028.xml</output-file>
    </test-case>
-   <test-case is-XPath2="true" name="ForExpr029" FilePath="Expressions/FLWORExpr/ForExpr/" scenario="standard" Creator="NIST">
+   <test-case is-XPath2="false" name="ForExpr029" FilePath="Expressions/FLWORExpr/ForExpr/" scenario="standard" Creator="NIST">
       <description>Embedded FLOWR expression that binds same variable on both expressions (two for clauses).</description>
       <spec-citation spec="XQuery" section-number="3.8.1" section-title="For and Let Clauses" section-pointer="id-for-let"/>
       <query name="ForExpr029" date="2006-01-24"/>


### PR DESCRIPTION
Fixes #84 
Fixes #85

> :memo: Note that one of the tests which is now excluded was previously passing because the test suite transformation removes schema import lines, as several tests which contain them are not specifically related to schema import are valuable in the XPath 2.0 test suite. The test excluded here was intended to test the schema import specifically, so even though it "passed" it wasn't providing valuable information.
