### PR TITLE
Multiple bug fixes and improvements for regex behavior

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
@@ -86,7 +86,7 @@ public abstract class AbstractRegExFunction extends Function {
 	 * except for whitespace characters appearing within a character class
 	 * construct.
 	 */
-	protected static String removeWhitespace(String pattern) {
+	private static String removeWhitespace(String pattern) {
 		StringBuilder builder = new StringBuilder();
 		int index = 0;
 		while (index < pattern.length()) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
@@ -13,6 +13,7 @@ package org.eclipse.wst.xml.xpath2.processor.internal.function;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
 import org.eclipse.wst.xml.xpath2.processor.internal.types.QName;
@@ -69,8 +70,14 @@ public abstract class AbstractRegExFunction extends Function {
 				}
 			}
 		}
-		
-		Pattern p = Pattern.compile(pattern, flag);
+
+		Pattern p;
+		try {
+			p = Pattern.compile(pattern, flag);
+		} catch (PatternSyntaxException ex) {
+			throw DynamicError.regex_error(null, ex);
+		}
+
 		return p.matcher(src);
 	}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/AbstractRegExFunction.java
@@ -30,9 +30,7 @@ public abstract class AbstractRegExFunction extends Function {
 	
 	protected static boolean matches(String pattern, String flags, String src) {
 		boolean fnd = false;
-		if (pattern.indexOf("-[") != -1) {
-			pattern = pattern.replaceAll("\\-\\[", "&&[^");
-		}
+		pattern = pattern.replace("-[", "&&[^");
 		Matcher m = compileAndExecute(pattern, flags, src);
 		while (m.find()) {
 			fnd = true;

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMatches.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnMatches.java
@@ -86,13 +86,8 @@ public class FnMatches extends AbstractRegExFunction {
 			flags = flagRS.first().getStringValue();
 		}
 
-		try {
-			boolean result = false;
-			result = matches(pattern, flags, str1);
-			return XSBoolean.valueOf(result);
-		} catch (PatternSyntaxException pex) {
-			throw DynamicError.regex_error(pex.getMessage(), pex);
-		}
+		boolean result = matches(pattern, flags, str1);
+		return XSBoolean.valueOf(result);
 	}
 	
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
@@ -85,20 +85,8 @@ public class FnReplace extends AbstractRegExFunction {
 		String replacement = ((XSString) arg3.first()).value();
 		
 		try {
-			Matcher matcher = null;
-			if (flags != null) {
-				if ("x".equals(flags)) {
-					pattern = removeWhitespace(pattern);
-				} else {
-					matcher = regex(pattern, flags, str1);
-				}
-			}
-
-			if (matcher == null) {
-				return new XSString(str1.replaceAll(pattern, replacement));
-			} else {
-				return new XSString(matcher.replaceAll(replacement));
-			}
+			Matcher matcher = regex(pattern, flags, str1);
+			return new XSString(matcher.replaceAll(replacement));
 		} catch (PatternSyntaxException err) {
 			throw DynamicError.regex_error(null, err);
 		} catch (IllegalArgumentException ex) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.regex.Matcher;
-import java.util.regex.PatternSyntaxException;
 
 import org.eclipse.wst.xml.xpath2.api.ResultSequence;
 import org.eclipse.wst.xml.xpath2.processor.DynamicError;
@@ -106,8 +105,6 @@ public class FnReplace extends AbstractRegExFunction {
 			}
 
 			return new XSString(matcher.replaceAll(replacement));
-		} catch (PatternSyntaxException err) {
-			throw DynamicError.regex_error(null, err);
 		} catch (IllegalArgumentException ex) {
 			throw new DynamicError("FORX0004", "Invalid replacement string.", ex);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
@@ -95,6 +95,11 @@ public class FnReplace extends AbstractRegExFunction {
 				matcher = regex(pattern, flags, str1);
 			}
 
+			// Validate non-empty match
+			if (matcher.find() && matcher.end() == 0) {
+				throw new DynamicError("FORX0003", "Regular expression matches zero-length string.", null);
+			}
+
 			// Validate replacement
 			if (!isSyntacticallyValidReplacementString(replacement)) {
 				throw new DynamicError("FORX0004", "Invalid replacement string.", null);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
@@ -31,7 +31,7 @@ import org.eclipse.wst.xml.xpath2.processor.internal.types.XSString;
  * non-overlapping substring of $input that matches the given $pattern with an
  * occurrence of the $replacement string.
  */
-public class FnReplace extends Function {
+public class FnReplace extends AbstractRegExFunction {
 	private static Collection<SeqType> _expected_args = null;
 
 	/**
@@ -88,9 +88,9 @@ public class FnReplace extends Function {
 			Matcher matcher = null;
 			if (flags != null) {
 				if ("x".equals(flags)) {
-					pattern = AbstractRegExFunction.removeWhitespace(pattern);
+					pattern = removeWhitespace(pattern);
 				} else {
-					matcher = AbstractRegExFunction.regex(pattern, flags, str1);
+					matcher = regex(pattern, flags, str1);
 				}
 			}
 

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnReplace.java
@@ -109,6 +109,9 @@ public class FnReplace extends Function {
 				throw new DynamicError("FORX0004", "result out of bounds", ex);
 			}
 			throw new DynamicError("FORX0003", "invalid regex.", ex);
+		} catch (DynamicError ex) {
+			// Just rethrow this
+			throw ex;
 		} catch (Exception ex) {
 			throw new DynamicError("FORX0004", "invalid regex.", ex);
 		}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnTokenize.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/function/FnTokenize.java
@@ -88,15 +88,9 @@ public class FnTokenize extends AbstractRegExFunction {
 			flags = flagRS.first().getStringValue();
 		}
 
-		try {
-			ArrayList<String> ret = tokenize(pattern, flags, str1);
-
-			for (Iterator<String> retIter = ret.iterator(); retIter.hasNext();) {
-			   rs.add(new XSString(retIter.next()));	
-			}
-			
-		} catch (PatternSyntaxException err) {
-			throw DynamicError.regex_error(null, err);
+		ArrayList<String> ret = tokenize(pattern, flags, str1);
+		for (Iterator<String> retIter = ret.iterator(); retIter.hasNext();) {
+			rs.add(new XSString(retIter.next()));
 		}
 
 		return rs.getSequence();

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XPathDecimalFormat.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XPathDecimalFormat.java
@@ -54,7 +54,7 @@ public class XPathDecimalFormat extends DecimalFormat {
 
 	private String formatXPath(Object obj) {
 		String curPattern = toPattern();
-		String newPattern = curPattern.replaceAll("E0", "");
+		String newPattern = curPattern.replace("E0", "");
 		if (obj instanceof Float) {
             return formatFloatValue((Float) obj, curPattern, newPattern);
 		}
@@ -84,7 +84,7 @@ public class XPathDecimalFormat extends DecimalFormat {
 		if (doubValue.compareTo(minValue) > 0 && doubValue.compareTo(maxValue) < 0) {
 			applyPattern(newPattern);
 		} else { //if (doubValue.compareTo(minValue) < 0) {
-			applyPattern(curPattern.replaceAll("0\\.#", "0.0"));
+			applyPattern(curPattern.replace("0.#", "0.0"));
 		}
 	}
 
@@ -122,7 +122,7 @@ public class XPathDecimalFormat extends DecimalFormat {
 			
 			applyPattern(newPattern);
 		} else if (floatValue <= -1E6f) {
-			applyPattern(curPattern.replaceAll("0\\.#", "0.0" ));
+			applyPattern(curPattern.replace("0.#", "0.0" ));
 		}
 	}
 	

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGDay.java
@@ -101,7 +101,7 @@ public class XSGDay extends CalendarType implements CmpEq {
 			}
 			
 			String[] split = str.split("-");
-			startdate += split[3].replaceAll("Z", "");
+			startdate += split[3].replace("Z", "");
 			
 			if (str.indexOf('T') != -1) {
 				if (split.length > 4) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonth.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonth.java
@@ -98,7 +98,7 @@ public class XSGMonth extends CalendarType implements CmpEq {
 			}
 			
 			String[] split = str.split("-");
-			startdate += split[2].replaceAll("Z", "") + "-01";
+			startdate += split[2].replace("Z", "") + "-01";
 			
 			if (str.indexOf('T') != -1) { 
 				if (split.length > 3) {

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonthDay.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGMonthDay.java
@@ -105,7 +105,7 @@ public class XSGMonthDay extends CalendarType implements CmpEq {
 
 			
 			String[] split = str.split("-");
-			startdate += split[2].replaceAll("Z", "") + "-" + split[3].replaceAll("Z", "").substring(0, 2);
+			startdate += split[2].replace("Z", "") + "-" + split[3].replace("Z", "").substring(0, 2);
 			
 			if (split.length > 4) {
 				String[] timesplit = split[4].split(":");

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/test/org/eclipse/wst/xml/xpath2/test/TestRegexBehavior.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/test/org/eclipse/wst/xml/xpath2/test/TestRegexBehavior.java
@@ -1,0 +1,141 @@
+package org.eclipse.wst.xml.xpath2.test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerException;
+
+import org.eclipse.wst.xml.xpath2.api.DynamicContext;
+import org.eclipse.wst.xml.xpath2.api.ResultSequence;
+import org.eclipse.wst.xml.xpath2.api.StaticContext;
+import org.eclipse.wst.xml.xpath2.api.XPath2Expression;
+import org.eclipse.wst.xml.xpath2.processor.DynamicError;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Node;
+
+public class TestRegexBehavior extends XPathTestBase {
+
+	@Test
+	public void testReplacementReferenceLeadingZero() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		String query = "fn:replace(\"abc\", \"abc\", \"x$00\")";
+		if (isDebug()) {
+			System.out.println(query);
+		}
+
+		XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+		Node[] contextItems = new Node[] { };
+		ResultSequence result = expression.evaluate(dynamicContext, contextItems);
+
+		String actual = serializeResultSequence(result);
+		Assert.assertThat(actual, equalTo("xabc"));
+	}
+
+	@Test
+	public void testReplacementReferenceLeadingZeroHigh() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		for (int i = 1; i <= 9; i++) {
+			String query = "fn:replace(\"abc\", \"abc\", \"x$0" + String.valueOf(i) + "\")";
+			if (isDebug()) {
+				System.out.println(query);
+			}
+
+			XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+			Node[] contextItems = new Node[] { };
+			ResultSequence result = expression.evaluate(dynamicContext, contextItems);
+
+			String actual = serializeResultSequence(result);
+			Assert.assertThat(actual, equalTo("x"));
+		}
+	}
+
+	@Test
+	public void testReplacementReferenceHigh() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		for (int i = 1; i <= 9; i++) {
+			String query = "fn:replace(\"abc\", \"abc\", \"x$" + String.valueOf(i) + "\")";
+			if (isDebug()) {
+				System.out.println(query);
+			}
+
+			XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+			Node[] contextItems = new Node[] { };
+			ResultSequence result = expression.evaluate(dynamicContext, contextItems);
+
+			String actual = serializeResultSequence(result);
+			Assert.assertThat(actual, equalTo("x"));
+		}
+	}
+
+	@Test
+	public void testReplacementReferenceHighDoubleDigit() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		for (int i = 1; i <= 9; i++) {
+			String query = "fn:replace(\"abc\", \"abc\", \"x$" + String.valueOf(i) + "0\")";
+			if (isDebug()) {
+				System.out.println(query);
+			}
+
+			XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+			Node[] contextItems = new Node[] { };
+			ResultSequence result = expression.evaluate(dynamicContext, contextItems);
+
+			String actual = serializeResultSequence(result);
+			Assert.assertThat(actual, equalTo("x0"));
+		}
+	}
+
+	@Test
+	public void testReplacementReference23() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		String query = "fn:replace(\"abcd\", \"(a)(b)(c)(d)\", \"x$23\")";
+		if (isDebug()) {
+			System.out.println(query);
+		}
+
+		XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+		Node[] contextItems = new Node[] { };
+		ResultSequence result = expression.evaluate(dynamicContext, contextItems);
+
+		String actual = serializeResultSequence(result);
+		Assert.assertThat(actual, equalTo("xb3"));
+	}
+
+	/**
+	 * This is a regression test for https://github.com/sharwell/webtools.sourceediting.xpath/issues/159.
+	 */
+	@Test
+	public void testReplaceExpressionCannotMatchEmpty() throws TransformerException, ParserConfigurationException {
+		StaticContext staticContext = createStaticContextBuilder();
+		DynamicContext dynamicContext = createDynamicContextBuilder(staticContext);
+
+		String query = "fn:replace(\"abc\", \"\", \"a\")";
+		if (isDebug()) {
+			System.out.println(query);
+		}
+
+		XPath2Expression expression = getEngine().parseExpression(query, staticContext);
+		Node[] contextItems = new Node[] { };
+
+		try {
+			expression.evaluate(dynamicContext, contextItems);
+			fail("Expected an exception: FORX0003");
+		} catch (DynamicError ex) {
+			assertEquals("FORX0003", ex.code());
+		}
+	}
+
+}


### PR DESCRIPTION
Bug fixes:
- Fixes #157 
- Fixes #158 
- Fixes #159 

Enhancements:
- Fixes #27 
- Use `replace` instead of `replaceAll` where appropriate for efficiency

Several test cases were added covering some edge cases I identified during the implementation.
