### PR TITLE
The year before 1AD is 1BC

### DIFF
--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDate.java
@@ -202,8 +202,9 @@ Cloneable {
 	 */
 	public int year() {
 		int y = _calendar.get(Calendar.YEAR);
-		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC)
-			y *= -1;
+		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+			y = 1 - y;
+		}
 
 		return y;
 	}
@@ -247,11 +248,15 @@ Cloneable {
 
 		Calendar adjustFortimezone = calendar();
 
+		int year = adjustFortimezone.get(Calendar.YEAR);
 		if (adjustFortimezone.get(Calendar.ERA) == GregorianCalendar.BC) {
-			ret += "-";
+			year--;
+			if (year > 0) {
+				ret += "-";
+			}
 		}
 
-		ret += XSDateTime.pad_int(adjustFortimezone.get(Calendar.YEAR), 4);
+		ret += XSDateTime.pad_int(year, 4);
 
 		ret += "-";
 		ret += XSDateTime.pad_int(month(), 2);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSDateTime.java
@@ -445,8 +445,8 @@ Cloneable {
 
 		// year
 		int year = d[0];
-		if (year < 0) {
-			year *= -1;
+		if (year <= 0) {
+			year = 1 - year;
 			cal.set(Calendar.ERA, GregorianCalendar.BC);
 		} else {
 			cal.set(Calendar.ERA, GregorianCalendar.AD);
@@ -570,8 +570,9 @@ Cloneable {
 	 */
 	public int year() {
 		int y = _calendar.get(Calendar.YEAR);
-		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC)
-			y *= -1;
+		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+			y = 1 - y;
+		}
 
 		return y;
 	}
@@ -675,11 +676,15 @@ Cloneable {
 
 		Calendar adjustFortimezone = calendar();
 
+		int year = adjustFortimezone.get(Calendar.YEAR);
 		if (adjustFortimezone.get(Calendar.ERA) == GregorianCalendar.BC) {
-			ret += "-";
+			year--;
+			if (year > 0) {
+				ret += "-";
+			}
 		}
 
-		ret += pad_int(adjustFortimezone.get(Calendar.YEAR), 4);
+		ret += pad_int(year, 4);
 
 		ret += "-";
 		ret += pad_int(month(), 2);

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYear.java
@@ -169,8 +169,9 @@ public class XSGYear extends CalendarType implements CmpEq {
 	 */
 	public int year() {
 		int y = _calendar.get(Calendar.YEAR);
-		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC)
-			y *= -1;
+		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+			y = 1 - y;
+		}
 
 		return y;
 	}

--- a/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYearMonth.java
+++ b/bundles/org.eclipse.wst.xml.xpath2.processor/src/org/eclipse/wst/xml/xpath2/processor/internal/types/XSGYearMonth.java
@@ -172,8 +172,9 @@ public class XSGYearMonth extends CalendarType implements CmpEq {
 	 */
 	public int year() {
 		int y = _calendar.get(Calendar.YEAR);
-		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC)
-			y *= -1;
+		if (_calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+			y = 1 - y;
+		}
 
 		return y;
 	}


### PR DESCRIPTION
This change ensures the proper year is set on `Calendar` instances.
